### PR TITLE
docs(openclaw-plugin): expand troubleshooting guide

### DIFF
--- a/packages/openclaw-plugin/docs/troubleshooting.md
+++ b/packages/openclaw-plugin/docs/troubleshooting.md
@@ -2,6 +2,28 @@
 
 This page covers common operational issues for `@call-e/openagent`.
 
+## Quick triage
+
+Use this page when you see one of these symptoms:
+
+- `429 Rate limit exceeded` during `openclaw plugins install`.
+- Plugin tool calls keep returning an authentication-required response.
+- The remote MCP endpoint returns `401` or `403`.
+- Browser login completed, but the next tool call still asks you to authenticate.
+- The plugin works in one OpenClaw surface, but not from your current chat surface.
+
+## Before deeper troubleshooting
+
+Check these basics first:
+
+1. Confirm the plugin is installed.
+2. Confirm `calle` is present in `plugins.allow`.
+3. Confirm `plugins.entries.calle.enabled` is `true`.
+4. Restart `openclaw-gateway` after changing plugin configuration.
+5. Retry the same tool call once after the restart.
+
+This avoids chasing auth or network issues when the plugin was never loaded by the running gateway process.
+
 ## ClawHub install fails with `429 Rate limit exceeded`
 
 Example install command:
@@ -90,3 +112,35 @@ If the problem persists:
 - Verify the remote broker endpoints listed in the service contract.
 - Verify that the remote MCP endpoint is reachable from the machine running `openclaw-gateway`.
 - Verify that the configured `serverUrl` matches the environment where the login flow is being completed.
+
+## Why does the plugin work in Web UI but not from my current chat surface?
+
+What this usually means:
+
+- The plugin itself may be installed and healthy.
+- The current OpenClaw surface may not expose the same native tool path as another surface.
+- The current chat surface may be falling back to `exec` for related actions.
+- That fallback path may require separate exec approval routing or approver configuration.
+
+This can look like a plugin failure even when the plugin was never actually invoked.
+
+What to check:
+
+1. Retry the same operation from another OpenClaw surface, such as Web UI, to confirm whether the issue is surface-specific.
+2. Check whether the current chat surface supports native exec approvals.
+3. If you use Discord, verify the current gateway config for:
+   - `channels.discord.execApprovals.enabled`
+   - `channels.discord.execApprovals.approvers`
+   - `commands.ownerAllowFrom`
+4. If the chat surface falls back to `exec`, verify that the approval prompt can actually be delivered and resolved in that surface.
+
+What happens after the fix:
+
+- The same user action should stop failing at the approval or surface-routing layer.
+- The plugin tool call should either execute normally or return a plugin-specific error instead of failing before invocation.
+
+If the problem persists:
+
+- Compare the behavior between Web UI and the failing chat surface.
+- Confirm that the running gateway has reloaded the latest channel approval configuration.
+- Confirm that the plugin is being reached at all, rather than failing in a pre-plugin approval path.


### PR DESCRIPTION
## Summary

Expand the OpenClaw plugin troubleshooting guide with more practical navigation and chat-surface debugging guidance.

## Changes

- add a quick triage section at the top
- add basic preflight checks before deeper troubleshooting
- keep the existing install/auth troubleshooting content
- add a new section for cases where the plugin works in Web UI but not from the current chat surface
- document Discord exec approval and surface-specific troubleshooting direction

## Why

The original page was already useful, but it was still easy for users to get stuck on where to start or to misdiagnose chat-surface approval issues as plugin failures.

This change makes the page more actionable without changing its overall style.
