### PR TITLE
fix: sync Codex plugin manifest version

### DIFF
--- a/packages/codex-plugin/plugin/.codex-plugin/plugin.json
+++ b/packages/codex-plugin/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "calle",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Use Call-E from Codex through the calle CLI.",
   "homepage": "https://github.com/CALLE-AI/call-e-integrations/tree/main/packages/codex-plugin",
   "repository": "https://github.com/CALLE-AI/call-e-integrations",

--- a/scripts/check-manifest-versions.mjs
+++ b/scripts/check-manifest-versions.mjs
@@ -18,22 +18,38 @@ for (const entry of fs.readdirSync(packagesDir, { withFileTypes: true })) {
 
   const packageDir = path.join(packagesDir, entry.name);
   const packageJsonPath = path.join(packageDir, "package.json");
-  const manifestPath = path.join(packageDir, "openclaw.plugin.json");
+  const manifestPaths = [
+    {
+      label: "openclaw.plugin.json",
+      path: path.join(packageDir, "openclaw.plugin.json"),
+    },
+    {
+      label: "plugin/.codex-plugin/plugin.json",
+      path: path.join(packageDir, "plugin", ".codex-plugin", "plugin.json"),
+    },
+  ];
   const indexPath = path.join(packageDir, "index.js");
 
-  if (!fs.existsSync(packageJsonPath) || !fs.existsSync(manifestPath)) {
+  if (!fs.existsSync(packageJsonPath)) {
     continue;
   }
 
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
   const packageVersion = packageJson.version;
-  const manifestVersion = manifest.version;
 
-  if (packageVersion !== manifestVersion) {
-    failures.push(
-      `${entry.name}: package.json version (${packageVersion}) does not match openclaw.plugin.json version (${manifestVersion}).`
-    );
+  for (const manifestPath of manifestPaths) {
+    if (!fs.existsSync(manifestPath.path)) {
+      continue;
+    }
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath.path, "utf8"));
+    const manifestVersion = manifest.version;
+
+    if (packageVersion !== manifestVersion) {
+      failures.push(
+        `${entry.name}: package.json version (${packageVersion}) does not match ${manifestPath.label} version (${manifestVersion}).`
+      );
+    }
   }
 
   if (fs.existsSync(indexPath)) {

--- a/scripts/sync-plugin-manifest-version.mjs
+++ b/scripts/sync-plugin-manifest-version.mjs
@@ -17,20 +17,29 @@ for (const entry of fs.readdirSync(packagesDir, { withFileTypes: true })) {
 
   const packageDir = path.join(packagesDir, entry.name);
   const packageJsonPath = path.join(packageDir, "package.json");
-  const manifestPath = path.join(packageDir, "openclaw.plugin.json");
+  const manifestPaths = [
+    path.join(packageDir, "openclaw.plugin.json"),
+    path.join(packageDir, "plugin", ".codex-plugin", "plugin.json"),
+  ];
   const indexPath = path.join(packageDir, "index.js");
 
-  if (!fs.existsSync(packageJsonPath) || !fs.existsSync(manifestPath)) {
+  if (!fs.existsSync(packageJsonPath)) {
     continue;
   }
 
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
   const version = packageJson.version;
 
-  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
-  if (manifest.version !== version) {
-    manifest.version = version;
-    fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  for (const manifestPath of manifestPaths) {
+    if (!fs.existsSync(manifestPath)) {
+      continue;
+    }
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+    if (manifest.version !== version) {
+      manifest.version = version;
+      fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+    }
   }
 
   if (fs.existsSync(indexPath)) {


### PR DESCRIPTION
## Summary
- sync the Codex plugin manifest version to 0.1.0 after the release bump
- update version sync/check scripts to include plugin/.codex-plugin/plugin.json

## Verification
- pnpm test
- pnpm check
- pnpm pack:dry-run