### PR TITLE
docs(codex-plugin): add registry trust metadata

### DIFF
--- a/.changeset/distribution-entry-points.md
+++ b/.changeset/distribution-entry-points.md
@@ -2,4 +2,4 @@
 "@call-e/codex-plugin": patch
 ---
 
-Improve Codex plugin search keywords for marketplace and package discovery.
+Improve Codex plugin metadata for marketplace discovery and trust scanning.

--- a/packages/codex-plugin/plugin/.codex-plugin/plugin.json
+++ b/packages/codex-plugin/plugin/.codex-plugin/plugin.json
@@ -2,6 +2,10 @@
   "name": "calle",
   "version": "0.1.1",
   "description": "Use Call-E from Codex through the calle CLI.",
+  "author": {
+    "name": "CALLE AI",
+    "url": "https://github.com/CALLE-AI"
+  },
   "homepage": "https://github.com/CALLE-AI/call-e-integrations/tree/main/packages/codex-plugin",
   "repository": "https://github.com/CALLE-AI/call-e-integrations",
   "license": "MIT",

--- a/packages/codex-plugin/plugin/.codexignore
+++ b/packages/codex-plugin/plugin/.codexignore
@@ -1,0 +1,5 @@
+node_modules/
+.git/
+.DS_Store
+*.log
+*.tmp

--- a/packages/codex-plugin/plugin/LICENSE
+++ b/packages/codex-plugin/plugin/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Call-E contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/codex-plugin/plugin/README.md
+++ b/packages/codex-plugin/plugin/README.md
@@ -1,0 +1,39 @@
+# Calle for Codex
+
+Use Call-E from Codex through the `calle` CLI.
+
+This plugin provides the `$calle` skill for setup checks, authentication
+recovery, phone call planning, planned call execution, and call status checks.
+It reuses the `@call-e/cli` package so authentication, token caching, JSON
+output, and MCP error handling stay owned by the CLI.
+
+## Install
+
+Add the Call-E Codex marketplace from the repository root:
+
+```bash
+codex plugin marketplace add CALLE-AI/call-e-integrations \
+  --ref '@call-e/codex-plugin@0.1.1' \
+  --sparse .agents/plugins \
+  --sparse packages/codex-plugin/plugin
+```
+
+Open Codex, run `/plugins`, choose the `Call-E` marketplace, and install
+`Calle`.
+
+## Authentication
+
+The plugin uses the repository-local CLI when available, then a global `calle`
+command when available, then falls back to `npx -y @call-e/cli@0.1.0`.
+
+To authenticate before using the plugin:
+
+```bash
+npx -y @call-e/cli@0.1.0 auth login
+```
+
+## Safety
+
+Call-E can place real phone calls. The skill plans first, uses returned
+credentials exactly as provided, and does not place a call unless the user
+clearly intends to do so.

--- a/packages/codex-plugin/plugin/SECURITY.md
+++ b/packages/codex-plugin/plugin/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Supported Package
+
+Security fixes are provided for the latest published version of
+`@call-e/codex-plugin`.
+
+## Reporting A Vulnerability
+
+Please report security issues privately to `security@call-e.ai`.
+
+When possible, include:
+
+- a description of the issue
+- affected package version
+- reproduction steps
+- impact assessment
+
+We will acknowledge reports as quickly as practical and work with reporters on
+coordinated disclosure.
+
+Please do not open public GitHub issues for undisclosed vulnerabilities.

--- a/packages/codex-plugin/plugin/skills/calle/SKILL.md
+++ b/packages/codex-plugin/plugin/skills/calle/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: calle
 description: Use Call-E from Codex through the calle CLI. Use for Call-E setup checks, authentication recovery, phone call planning, planned call execution, and call status checks.
+license: MIT
 ---
 
 # Call-E


### PR DESCRIPTION
## Summary
- add plugin-bundle README, LICENSE, SECURITY, and .codexignore files for registry trust scanning
- add structured author metadata to the Codex plugin manifest
- declare the bundled skill license

## Validation
- pnpm check
- pnpm test
- pnpm --filter @call-e/codex-plugin pack:dry-run
- uvx codex-plugin-scanner verify packages/codex-plugin/plugin
- uvx codex-plugin-scanner lint packages/codex-plugin/plugin