### PR TITLE
feat(cli): add start-only brokered auth login

### DIFF
--- a/.changeset/fair-chairs-approve.md
+++ b/.changeset/fair-chairs-approve.md
@@ -1,0 +1,6 @@
+---
+"@call-e/cli": minor
+"@call-e/codex-plugin": patch
+---
+
+Add start-only brokered login output for integrations and update the Codex plugin authorization flow guidance.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -14,6 +14,7 @@ npm install -g @call-e/cli
 
 ```bash
 calle auth login
+calle auth login --start-only --no-browser-open
 calle auth status
 calle auth logout
 calle mcp config
@@ -33,6 +34,8 @@ Defaults:
 - Token cache: `~/.calle-mcp/cli`
 
 `calle auth login` opens the brokered login URL, polls the broker session, exchanges the authorized session, and stores the token in a private local cache. The token is not printed to stdout.
+
+`calle auth login --start-only --no-browser-open` creates or reuses a brokered login session and returns JSON with `login_url` and `assistant_hint.message` without polling for completion. This is intended for agent integrations that need to show the authorization link before continuing.
 
 `calle mcp config` prints a JSON MCP client config:
 
@@ -76,6 +79,7 @@ Common options:
 - `--timeout-seconds`
 - `--poll-timeout-seconds`
 - `--force-login`
+- `--start-only`
 - `--no-browser-open`
 - `--no-telemetry`
 - `--json`

--- a/packages/cli/lib/cli.js
+++ b/packages/cli/lib/cli.js
@@ -1,6 +1,6 @@
 import { pendingCachePath, readJson, removeFile, tokenCachePath, tokenIsUsable } from "./cache.js";
 import { DEFAULT_BASE_URL, DEFAULT_CHANNEL, DEFAULT_CLIENT_NAME, DEFAULT_SCOPE, resolveRuntimeConfig } from "./config.js";
-import { loginWithBroker } from "./broker-client.js";
+import { ensurePendingLogin, loginWithBroker } from "./broker-client.js";
 import {
   AuthRequiredError,
   McpHttpError,
@@ -17,13 +17,29 @@ class InvalidArgumentsError extends Error {
   }
 }
 
-export const POST_AUTH_HELP_MESSAGE = `Hi, I’m CALL-E 👋
+export function preAuthHelpMessage(loginUrl) {
+  return `Hi, I'm CALL-E 👋
 
-I can help make phone calls, gather information, and handle phone-based tasks like appointments, reservations, follow-ups, and customer service requests.
+I can help you make phone calls, ask for information, and handle phone-related tasks. I'll also keep you updated on the call status, what was discussed, and the key points.
+Before we officially begin, I'll send you the call goal for confirmation.
 
-Before each call, I’ll confirm the goal and key details with you. Afterward, I’ll share the status, summary, key takeaways, and next steps.`;
+Before we start, please complete authorization here:
+${loginUrl}`;
+}
+
+export const POST_AUTH_HELP_MESSAGE = `Great, authorization is complete ✨
+
+- If you already shared the call goal, I'll continue as planned.
+- If you haven't, that's okay. I can help you place a test call first, or start a real call directly.
+
+You can tell me:
+- Your phone number: Used only for this service. We will not disclose it to anyone else, including the callee.
+- What you want me to say: For example, "This is a test call from CALL-E. Wishing you a good day, and asking if there's anything you'd like to share."
+
+I'll keep you updated on the phone status, call content, and summary.`;
 
 const POST_AUTH_HELP_HINT_TYPE = "post_auth_help";
+const PRE_AUTH_HELP_HINT_TYPE = "pre_auth_help";
 
 function printHelp(stdout) {
   stdout(`Usage: calle <command> [options]
@@ -52,6 +68,7 @@ Common options:
   --poll-timeout-seconds <seconds>
   --server-name <name>          Default: calle
   --force-login
+  --start-only
   --no-browser-open
   --no-telemetry
   --json
@@ -77,7 +94,15 @@ function toCamelCase(optionName) {
 function parseOptions(argv) {
   const options = {};
   const positional = [];
-  const booleanOptions = new Set(["force-login", "no-browser-open", "no-telemetry", "telemetry", "json", "help"]);
+  const booleanOptions = new Set([
+    "force-login",
+    "start-only",
+    "no-browser-open",
+    "no-telemetry",
+    "telemetry",
+    "json",
+    "help",
+  ]);
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (!arg.startsWith("--")) {
@@ -182,6 +207,31 @@ function postAuthAssistantHint(status) {
   };
 }
 
+function preAuthAssistantHint(loginUrl) {
+  if (typeof loginUrl !== "string" || !loginUrl.trim()) {
+    return null;
+  }
+  return {
+    type: PRE_AUTH_HELP_HINT_TYPE,
+    message: preAuthHelpMessage(loginUrl.trim()),
+  };
+}
+
+function publicPendingLoginPayload({ config, cachePath, pendingPath, pending, created }) {
+  const assistantHint = preAuthAssistantHint(pending.login_url);
+  return {
+    status: "login_required",
+    broker_base_url: config.brokerBaseUrl,
+    server_url: config.serverUrl,
+    cache_path: cachePath,
+    pending_cache_path: pendingPath,
+    pending_status: pending.status,
+    pending_created: created,
+    login_url: pending.login_url,
+    ...(assistantHint ? { assistant_hint: assistantHint } : {}),
+  };
+}
+
 function publicLoginPayload({ config, cachePath, pendingPath, tokenDocument, status }) {
   const assistantHint = postAuthAssistantHint(status);
   return {
@@ -208,6 +258,8 @@ function statusPayload(config) {
     pending_exists: pendingDocument !== null,
     usable: tokenIsUsable(cacheDocument, config.minTtlSeconds),
     expires_at: cacheDocument?.expires_at ?? null,
+    pending_status: pendingDocument?.status ?? null,
+    pending_login_url: pendingDocument?.login_url ?? null,
   };
 }
 
@@ -271,6 +323,9 @@ function callStatusCommand(config, runId) {
 }
 
 function authRequiredPayload(config, message = "A usable Calle auth token is required.") {
+  const pendingDocument = readJson(pendingCachePath(config.cacheRoot, config.serverUrl));
+  const loginUrl = typeof pendingDocument?.login_url === "string" ? pendingDocument.login_url : null;
+  const assistantHint = preAuthAssistantHint(loginUrl);
   return {
     ok: false,
     server_url: config.serverUrl,
@@ -279,6 +334,8 @@ function authRequiredPayload(config, message = "A usable Calle auth token is req
       message,
     },
     login_command: loginCommand(config),
+    ...(loginUrl ? { login_url: loginUrl } : {}),
+    ...(assistantHint ? { assistant_hint: assistantHint } : {}),
   };
 }
 
@@ -603,8 +660,42 @@ export async function runCli(argv, deps = {}) {
     assertNoUnexpectedPositional(positional);
     await captureTelemetry("auth_login_local_started", {
       force_login: Boolean(options.forceLogin),
+      start_only: Boolean(options.startOnly),
       no_browser_open: Boolean(options.noBrowserOpen),
     });
+    const cachePath = tokenCachePath(config.cacheRoot, config.serverUrl);
+    const pendingPath = pendingCachePath(config.cacheRoot, config.serverUrl);
+    if (options.startOnly) {
+      const cached = readJson(cachePath);
+      if (!options.forceLogin && tokenIsUsable(cached, config.minTtlSeconds)) {
+        writeJson(stdout, publicLoginPayload({
+          config,
+          cachePath,
+          pendingPath,
+          tokenDocument: cached,
+          status: "cached",
+        }));
+        return 0;
+      }
+      let result;
+      try {
+        result = await ensurePendingLogin(config, {
+          fetchImpl: deps.fetchImpl || globalThis.fetch,
+          forceLogin: Boolean(options.forceLogin),
+        });
+      } catch (error) {
+        await captureTelemetry("auth_login_local_failed", errorTelemetryProperties(error));
+        throw error;
+      }
+      writeJson(stdout, publicPendingLoginPayload({
+        config,
+        cachePath,
+        pendingPath,
+        pending: result.pending,
+        created: result.created,
+      }));
+      return 0;
+    }
     let result;
     try {
       result = await loginWithBroker(config, {

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -4,7 +4,7 @@ import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { POST_AUTH_HELP_MESSAGE, runCli } from "../lib/cli.js";
+import { POST_AUTH_HELP_MESSAGE, preAuthHelpMessage, runCli } from "../lib/cli.js";
 import { pendingCachePath, tokenCachePath, writePrivateJson } from "../lib/cache.js";
 import { CLI_VERSION } from "../lib/config.js";
 
@@ -118,10 +118,59 @@ test("auth login defaults broker payload to openagent_oauth and hides token from
     type: "post_auth_help",
     message: POST_AUTH_HELP_MESSAGE,
   });
-  assert.match(payload.assistant_hint.message, /I can help make phone calls/);
+  assert.match(payload.assistant_hint.message, /Great, authorization is complete/);
   const tokenPayload = JSON.parse(fs.readFileSync(tokenCachePath(cacheRoot, payload.server_url), "utf8"));
   assert.equal(tokenPayload.token.access_token, "secret-token");
   assert.equal(fs.existsSync(pendingCachePath(cacheRoot, payload.server_url)), false);
+});
+
+test("auth login start-only returns authorization hint without polling", async () => {
+  const cacheRoot = makeTempRoot("calle-cli-login-start-only");
+  const loginUrl = "https://mcp.example/openagent-auth/sessions/session-1/start";
+  const requests = [];
+  const fetchImpl = async (url, init) => {
+    requests.push(`${init?.method} ${url}`);
+    if (String(url).endsWith("/api/v1/openagent-auth/sessions") && init?.method === "POST") {
+      return jsonResponse(
+        {
+          session_id: "session-1",
+          session_secret: "secret-1",
+          login_url: loginUrl,
+          status: "PENDING",
+          poll_after_ms: 1,
+          expires_at: "2030-01-01T00:00:00Z",
+        },
+        { status: 201 }
+      );
+    }
+    throw new Error(`unexpected request: ${init?.method} ${url}`);
+  };
+
+  const result = await run(
+    [
+      "auth",
+      "login",
+      "--start-only",
+      "--no-browser-open",
+      "--base-url",
+      "https://mcp.example",
+      "--cache-root",
+      cacheRoot,
+    ],
+    { fetchImpl }
+  );
+  const payload = JSON.parse(result.stdout);
+
+  assert.equal(result.code, 0);
+  assert.deepEqual(requests, ["POST https://mcp.example/api/v1/openagent-auth/sessions"]);
+  assert.equal(payload.status, "login_required");
+  assert.equal(payload.login_url, loginUrl);
+  assert.deepEqual(payload.assistant_hint, {
+    type: "pre_auth_help",
+    message: preAuthHelpMessage(loginUrl),
+  });
+  assert.match(payload.assistant_hint.message, /Before we start, please complete authorization here/);
+  assert.doesNotMatch(result.stdout, /secret-1/);
 });
 
 test("auth login returns post-auth assistant hint for cached login", async () => {
@@ -321,6 +370,20 @@ test("auth status reports missing, usable, and expired cache states", async () =
   payload = JSON.parse(result.stdout);
   assert.equal(payload.cache_exists, true);
   assert.equal(payload.usable, false);
+
+  writePrivateJson(pendingCachePath(cacheRoot, serverUrl), {
+    session_id: "session-1",
+    session_secret: "secret-1",
+    login_url: "https://mcp.example/openagent-auth/sessions/session-1/start",
+    status: "PENDING",
+    created_at: "2026-04-23T00:00:00Z",
+  });
+  result = await run(["auth", "status", "--base-url", "https://mcp.example", "--cache-root", cacheRoot]);
+  payload = JSON.parse(result.stdout);
+  assert.equal(payload.pending_exists, true);
+  assert.equal(payload.pending_status, "PENDING");
+  assert.equal(payload.pending_login_url, "https://mcp.example/openagent-auth/sessions/session-1/start");
+  assert.doesNotMatch(result.stdout, /secret-1/);
 });
 
 test("auth logout removes token and pending cache", async () => {
@@ -653,6 +716,24 @@ test("mcp commands return auth_required for missing or expired tokens", async ()
   assert.equal(payload.error.code, "auth_required");
   assert.match(payload.login_command, /calle auth login/);
   assert.doesNotMatch(result.stdout, /access_token/);
+
+  writePrivateJson(pendingCachePath(cacheRoot, serverUrl), {
+    session_id: "session-1",
+    session_secret: "secret-1",
+    login_url: "https://mcp.example/openagent-auth/sessions/session-1/start",
+    status: "PENDING",
+    created_at: "2026-04-23T00:00:00Z",
+  });
+  const pendingResult = await run(["mcp", "tools", "--base-url", "https://mcp.example", "--cache-root", cacheRoot], {
+    fetchImpl: async () => {
+      throw new Error("fetch should not be called");
+    },
+  });
+  const pendingPayload = JSON.parse(pendingResult.stdout);
+  assert.equal(pendingPayload.error.code, "auth_required");
+  assert.equal(pendingPayload.login_url, "https://mcp.example/openagent-auth/sessions/session-1/start");
+  assert.match(pendingPayload.assistant_hint.message, /Before we start, please complete authorization here/);
+  assert.doesNotMatch(pendingResult.stdout, /secret-1/);
 
   writePrivateJson(tokenCachePath(cacheRoot, serverUrl), {
     token: { access_token: "expired-token" },

--- a/packages/cli/test/e2e/cli-e2e.test.js
+++ b/packages/cli/test/e2e/cli-e2e.test.js
@@ -302,6 +302,42 @@ test("prints MCP config without contacting the server", async (t) => {
   assert.deepEqual(fake.state.failures, []);
 });
 
+test("starts brokered auth and returns an authorization hint without polling", async (t) => {
+  const fake = await startFakeServer();
+  const cacheRoot = makeTempCacheRoot();
+  t.after(() => fake.close());
+  t.after(() => fs.rmSync(cacheRoot, { recursive: true, force: true }));
+
+  const result = await runCalle([
+    "auth",
+    "login",
+    "--start-only",
+    "--no-browser-open",
+    "--base-url",
+    fake.baseUrl,
+    "--broker-base-url",
+    fake.baseUrl,
+    "--cache-root",
+    cacheRoot,
+  ]);
+  const payload = parseJson(result.stdout);
+
+  assert.equal(result.code, 0);
+  assert.equal(payload.status, "login_required");
+  assert.equal(payload.login_url, `${fake.baseUrl}/openagent-auth/sessions/session-1/start`);
+  assert.match(payload.assistant_hint.message, /Before we start, please complete authorization here/);
+  assert.equal(fake.state.brokerCreates.length, 1);
+  assert.equal(fake.state.brokerStatusCount, 0);
+  assert.equal(fake.state.brokerExchangeCount, 0);
+  assertNoLeak(`${result.stdout}\n${result.stderr}`, [accessToken, sessionSecret]);
+  assert.deepEqual(fake.state.telemetryEvents.map((event) => event.event), [
+    "cli_invoked",
+    "auth_login_local_started",
+  ]);
+  assertNoLeak(JSON.stringify(fake.state.telemetryEvents), [accessToken, sessionSecret, payload.login_url]);
+  assert.deepEqual(fake.state.failures, []);
+});
+
 test("logs in through the fake broker and reports cache status", async (t) => {
   const fake = await startFakeServer();
   const cacheRoot = makeTempCacheRoot();

--- a/packages/codex-plugin/README.md
+++ b/packages/codex-plugin/README.md
@@ -55,6 +55,11 @@ to let Codex handle Call-E setup checks, authentication recovery, call
 planning, automatic call execution after planning completes, and call status
 checks.
 
+When `$calle` is invoked, the skill checks `calle auth status` first. If the
+user is not authorized, it runs blocking `calle auth login`, shows the brokered
+authorization link, and continues automatically after browser authorization
+completes.
+
 ## Telemetry / Usage Data
 
 When Codex runs the bundled Call-E skill, the skill invokes the shared `calle` CLI with source attribution environment variables so local telemetry and service-side call data can be grouped as `codex/codex_plugin/<version>`.

--- a/packages/codex-plugin/plugin/README.md
+++ b/packages/codex-plugin/plugin/README.md
@@ -32,6 +32,11 @@ To authenticate before using the plugin:
 npx -y @call-e/cli@0.2.1 auth login
 ```
 
+When `$calle` is invoked, the skill checks authorization first. If login is
+missing or expired, it runs blocking `calle auth login`, shows the brokered
+authorization link, and continues automatically after browser authorization
+completes.
+
 ## Safety
 
 Call-E can place real phone calls. The skill plans first, uses returned

--- a/packages/codex-plugin/plugin/skills/calle/SKILL.md
+++ b/packages/codex-plugin/plugin/skills/calle/SKILL.md
@@ -97,14 +97,41 @@ tool-listing commands until the user asks for a call workflow.
 3. If the user's request is to place a call, immediately use `call run` with
    the exact `plan_id` and `confirm_token` returned by planning.
 4. Do not ask for a second confirmation between `call plan` and `call run`.
-5. Read the returned `run_id`.
-6. If the latest status is not terminal, keep using `call status` with that
-   exact `run_id` until the call reaches a terminal status or the user asks you
-   to stop.
-7. Use `call status` only with a known `run_id`.
+5. Read the returned `run_id` and latest call status. In `call run` output, the
+   latest call state is in `status_result.structuredContent`. In `call status`
+   output, the latest call state is in `result.structuredContent`.
+6. If the latest status is not terminal, immediately show a user-visible
+   progress update from the latest activity data before polling again. Use
+   `status_result.structuredContent.activity` after `call run`, or
+   `result.structuredContent.activity` after `call status`.
+7. Keep using `call status` with that exact `run_id` until the call reaches a
+   terminal status or the user asks you to stop. Poll every 10 seconds: after
+   each non-terminal response, show the latest activity progress, wait 10
+   seconds, then fetch `call status` again. Do not stay silent until a terminal
+   status.
+8. Use `call status` only with a known `run_id`.
 
 Terminal statuses include `COMPLETED`, `FAILED`, `NO_ANSWER`, `DECLINED`,
 `CANCELED`, `CANCELLED`, `VOICEMAIL`, `BUSY`, and `EXPIRED`.
+
+For non-terminal statuses, reply with progress in this shape:
+
+```text
+Phone call is in progress! Progress:
+- <HH:MM:SS message>
+```
+
+Use one bullet per `activity` item, preserving the order returned by the CLI.
+For each item, prefer the event `ts` formatted as `HH:MM:SS` plus `message`.
+If `ts` is missing, use the message by itself. If there is no activity, use
+`- Status: <status>` when a status exists; otherwise use
+`- Waiting for the next status update.` Do not include the final summary,
+details, or transcript until a terminal status is returned.
+
+The polling cadence is: show progress, wait 10 seconds, run `call status`, show
+new progress if still non-terminal, then repeat. Stop polling immediately when
+the user asks you to stop, when a terminal status is returned, or when command
+execution is interrupted.
 
 When the call reaches a terminal status, reply with the final call result,
 including these sections in this order:

--- a/packages/codex-plugin/plugin/skills/calle/SKILL.md
+++ b/packages/codex-plugin/plugin/skills/calle/SKILL.md
@@ -74,21 +74,56 @@ command.
 
 ## Readiness flow
 
-Use this flow before call planning when setup is uncertain, when auth fails, or
-when the user asks to verify Call-E setup:
+Use this flow whenever this Codex plugin is actively invoked for a Call-E
+request. Run it before call planning, before tool listing, when setup is
+uncertain, when auth fails, or when the user asks to verify Call-E setup:
 
 1. Check CLI availability with `--help`.
 2. Run `auth status`.
-3. If auth is missing or expired, run or suggest `auth login`.
-4. After login completes, run `mcp tools`.
-5. Confirm that `plan_call`, `run_call`, and `get_call_run` are available.
-6. If the successful `auth login` JSON included `assistant_hint.message`, use
-   it to include a brief post-auth help note in the next user-facing reply
-   after tool availability is confirmed. Adapt the wording naturally to the
-   user's language and context.
+3. If `auth status` reports `usable: false`, do not continue to call planning
+   or `mcp tools` yet. Run blocking `auth login` and keep that command running
+   until it exits. Do not use `auth login --start-only --no-browser-open` for
+   the default Codex plugin flow.
+4. When `auth login` prints the brokered login URL to command output or stderr,
+   immediately show the first authorization help with that URL. Keep waiting
+   for the same `auth login` command to complete; do not ask the user to reply
+   after browser authorization.
+5. If the successful `auth login` JSON included `assistant_hint.message`, show
+   that post-auth success message in the next user-facing reply. If the user
+   already gave a call goal, continue the original workflow after the message;
+   otherwise ask for the phone number and call goal, or offer a test call.
+6. After login completes, run `mcp tools`.
+7. Confirm that `plan_call`, `run_call`, and `get_call_run` are available.
 
 Setup verification must not place a real phone call. Use only help, auth, and
 tool-listing commands until the user asks for a call workflow.
+
+First authorization help template:
+
+```text
+Hi, I'm CALL-E 👋
+
+I can help you make phone calls, ask for information, and handle phone-related tasks. I'll also keep you updated on the call status, what was discussed, and the key points.
+Before we officially begin, I'll send you the call goal for confirmation.
+
+Before we start, please complete authorization here:
+<login_url>
+```
+
+Post-authorization success template:
+
+```text
+Great, authorization is complete ✨
+
+- If you already shared the call goal, I'll continue as planned.
+- If you haven't, that's okay. I can help you place a test call first, or start a real call directly.
+
+You can tell me:
+- Your phone number: Used only for this service. We will not disclose it to anyone else, including the callee.
+- What you want me to say: For example, "This is a test call from CALL-E. Wishing you a good day, and asking if there's anything you'd like to share."
+
+I'll keep you updated on the phone status, call content, and summary.
+```
 
 ## Call flow
 

--- a/packages/codex-plugin/plugin/skills/calle/references/commands.md
+++ b/packages/codex-plugin/plugin/skills/calle/references/commands.md
@@ -93,9 +93,12 @@ Run this command immediately after planning returns a valid `plan_id` and
 `confirm_token`, when the user's request is to place a call. Preserve `plan_id`
 and `confirm_token` exactly as returned by planning.
 
-`call run` calls `run_call`, then fetches `get_call_run` once. If that status is
-not terminal, continue with `call status --run-id <run_id>` until a terminal
-status is returned or the user asks you to stop.
+`call run` calls `run_call`, then fetches `get_call_run` once. Read the latest
+call state from `status_result.structuredContent`. If that status is not
+terminal, show a user-visible progress update from
+`status_result.structuredContent.activity` immediately, then continue with
+`call status --run-id <run_id>` every 10 seconds until a terminal status is
+returned or the user asks you to stop.
 
 ## Call status
 
@@ -128,6 +131,31 @@ Terminal statuses:
 Read call data from `status_result.structuredContent` in `call run` output, or
 from `result.structuredContent` in `call status` output.
 
+For non-terminal statuses, show the latest activity before polling again:
+
+```text
+Phone call is in progress! Progress:
+- <HH:MM:SS message>
+```
+
+Use one bullet per `activity` item, preserving the order returned by the CLI.
+For `call run`, read activity from `status_result.structuredContent.activity`.
+For `call status`, read activity from `result.structuredContent.activity`.
+For each activity item, prefer the event `ts` formatted as `HH:MM:SS` plus
+`message`. If `ts` is missing, use the message by itself. If there is no
+activity, use `- Status: <status>` when a status exists; otherwise use
+`- Waiting for the next status update.` Do not wait silently for the terminal
+result.
+
+Polling cadence:
+
+1. Show the latest non-terminal progress.
+2. Wait 10 seconds.
+3. Run `call status --run-id <run_id>`.
+4. If the status is still non-terminal, show the new activity and repeat.
+5. Stop polling when a terminal status is returned, the user asks you to stop,
+   or command execution is interrupted.
+
 For terminal statuses, include the final transcript in the user-visible reply:
 
 ```text
@@ -156,6 +184,6 @@ short heading and only information present in the JSON output.
 - If `ok` is false and `error.code` is `auth_required`, run or suggest
   `auth login`, then retry after login completes.
 - Preserve `plan_id`, `confirm_token`, and `run_id` exactly as returned.
-- Summarize status clearly without exposing tokens.
+- Show non-terminal `activity` progress clearly without exposing tokens.
 - Do not invent transcript text. If `result.transcript` is absent or empty,
   write `Not available.` in the transcript section.

--- a/packages/codex-plugin/plugin/skills/calle/references/commands.md
+++ b/packages/codex-plugin/plugin/skills/calle/references/commands.md
@@ -47,16 +47,52 @@ Rules:
 
 - Treat all command output as JSON except `--help`.
 - Do not print or ask for access tokens.
-- If a command returns `auth_required`, run or suggest `auth login`.
+- Whenever this Codex plugin is actively invoked, run `auth status` before call
+  planning or tool listing.
+- If `auth status` reports `usable: false`, do not call `mcp tools` or
+  `call plan` yet. Run blocking `auth login` and keep that command running
+  until it exits. Do not use `auth login --start-only --no-browser-open` for
+  the default Codex plugin flow.
+- When `auth login` prints the brokered login URL to command output or stderr,
+  show the first authorization help with that URL. Keep waiting for the same
+  command to complete; do not ask the user to reply after browser
+  authorization.
+- If successful `auth login` output includes `assistant_hint.message`, show it
+  as the post-authorization success note. Then continue the original call
+  workflow if the user already gave enough details.
+- If a command returns `auth_required`, switch back to this auth flow.
 - If `mcp tools` succeeds, confirm that `plan_call`, `run_call`, and
   `get_call_run` are present.
-- If successful `auth login` output includes `assistant_hint.message`, use it
-  to include a brief post-auth help note in the next user-facing reply after
-  `mcp tools` confirms the required tools are present. Adapt the wording
-  naturally to the user's language and context.
 - Do not run `call run` during setup verification.
 - Do not use `.mcp.json`, raw HTTP, or direct remote MCP configuration in this
   plugin version.
+
+First authorization help template:
+
+```text
+Hi, I'm CALL-E 👋
+
+I can help you make phone calls, ask for information, and handle phone-related tasks. I'll also keep you updated on the call status, what was discussed, and the key points.
+Before we officially begin, I'll send you the call goal for confirmation.
+
+Before we start, please complete authorization here:
+<login_url>
+```
+
+Post-authorization success template:
+
+```text
+Great, authorization is complete ✨
+
+- If you already shared the call goal, I'll continue as planned.
+- If you haven't, that's okay. I can help you place a test call first, or start a real call directly.
+
+You can tell me:
+- Your phone number: Used only for this service. We will not disclose it to anyone else, including the callee.
+- What you want me to say: For example, "This is a test call from CALL-E. Wishing you a good day, and asking if there's anything you'd like to share."
+
+I'll keep you updated on the phone status, call content, and summary.
+```
 
 ## Call planning
 

--- a/packages/codex-plugin/scripts/check-plugin.mjs
+++ b/packages/codex-plugin/scripts/check-plugin.mjs
@@ -56,6 +56,35 @@ function checkSkill({ skillName, skillDir, failures }) {
     failures,
     `${skillFile} must document how to display assistant_hint.message after auth login.`,
   );
+  assert(
+    source.includes("Phone call is in progress! Progress:"),
+    failures,
+    `${skillFile} must document the non-terminal call activity progress template.`,
+  );
+  assert(
+    source.includes("Do not stay silent until a"),
+    failures,
+    `${skillFile} must require user-visible progress updates before terminal status.`,
+  );
+  assert(
+    source.includes("Poll every 10 seconds"),
+    failures,
+    `${skillFile} must document periodic polling while a call is non-terminal.`,
+  );
+
+  if (fs.existsSync(referenceFile)) {
+    const referenceSource = fs.readFileSync(referenceFile, "utf8");
+    assert(
+      referenceSource.includes("Phone call is in progress! Progress:"),
+      failures,
+      `${referenceFile} must document the non-terminal call activity progress template.`,
+    );
+    assert(
+      referenceSource.includes("Wait 10 seconds"),
+      failures,
+      `${referenceFile} must document the non-terminal call polling interval.`,
+    );
+  }
 
   if (!frontmatter) {
     return;

--- a/packages/codex-plugin/scripts/check-plugin.mjs
+++ b/packages/codex-plugin/scripts/check-plugin.mjs
@@ -57,6 +57,26 @@ function checkSkill({ skillName, skillDir, failures }) {
     `${skillFile} must document how to display assistant_hint.message after auth login.`,
   );
   assert(
+    source.includes("Run blocking `auth login`"),
+    failures,
+    `${skillFile} must document blocking authorization login for the default Codex plugin flow.`,
+  );
+  assert(
+    source.includes("do not ask the user to reply"),
+    failures,
+    `${skillFile} must document that browser authorization should continue without a manual chat reply.`,
+  );
+  assert(
+    source.includes("Before we start, please complete authorization here"),
+    failures,
+    `${skillFile} must include the first authorization help message.`,
+  );
+  assert(
+    source.includes("Great, authorization is complete"),
+    failures,
+    `${skillFile} must include the post-authorization success message.`,
+  );
+  assert(
     source.includes("Phone call is in progress! Progress:"),
     failures,
     `${skillFile} must document the non-terminal call activity progress template.`,
@@ -78,6 +98,26 @@ function checkSkill({ skillName, skillDir, failures }) {
       referenceSource.includes("Phone call is in progress! Progress:"),
       failures,
       `${referenceFile} must document the non-terminal call activity progress template.`,
+    );
+    assert(
+      referenceSource.includes("Run blocking `auth login`"),
+      failures,
+      `${referenceFile} must document blocking authorization login for the default Codex plugin flow.`,
+    );
+    assert(
+      referenceSource.includes("do not ask the user to reply"),
+      failures,
+      `${referenceFile} must document that browser authorization should continue without a manual chat reply.`,
+    );
+    assert(
+      referenceSource.includes("Before we start, please complete authorization here"),
+      failures,
+      `${referenceFile} must include the first authorization help message.`,
+    );
+    assert(
+      referenceSource.includes("Great, authorization is complete"),
+      failures,
+      `${referenceFile} must include the post-authorization success message.`,
     );
     assert(
       referenceSource.includes("Wait 10 seconds"),

--- a/packages/codex-plugin/test/check-plugin.test.js
+++ b/packages/codex-plugin/test/check-plugin.test.js
@@ -46,7 +46,7 @@ function createValidFixture(root) {
 
   writeFile(
     path.join(packageRoot, "plugin", "skills", "calle", "SKILL.md"),
-    "---\nname: calle\ndescription: Test skill.\n---\n\n# calle\n\nUse assistant_hint.message to include a brief post-auth help note after auth login.\n",
+    "---\nname: calle\ndescription: Test skill.\n---\n\n# calle\n\nUse assistant_hint.message to include a brief post-auth help note after auth login.\n\nPhone call is in progress! Progress:\n\nDo not stay silent until a terminal status.\n\nPoll every 10 seconds.\n",
   );
   writeFile(
     path.join(packageRoot, "plugin", "skills", "calle", "agents", "openai.yaml"),
@@ -54,7 +54,7 @@ function createValidFixture(root) {
   );
   writeFile(
     path.join(packageRoot, "plugin", "skills", "calle", "references", "commands.md"),
-    "# Commands\n",
+    "# Commands\n\nPhone call is in progress! Progress:\n\nWait 10 seconds.\n",
   );
 
   writeJson(path.join(repoRoot, ".agents", "plugins", "marketplace.json"), {
@@ -107,4 +107,26 @@ test("reports missing skill UI metadata", () => {
 
   const failures = checkCodexPlugin({ packageRoot, repoRoot });
   assert.ok(failures.some((failure) => failure.includes("agents/openai.yaml")));
+});
+
+test("reports missing non-terminal call progress guidance", () => {
+  const { packageRoot, repoRoot } = createValidFixture(makeTempRoot("calle-codex-plugin-missing-progress"));
+  writeFile(
+    path.join(packageRoot, "plugin", "skills", "calle", "SKILL.md"),
+    "---\nname: calle\ndescription: Test skill.\n---\n\n# calle\n\nUse assistant_hint.message to include a brief post-auth help note after auth login.\n",
+  );
+
+  const failures = checkCodexPlugin({ packageRoot, repoRoot });
+  assert.ok(failures.some((failure) => failure.includes("activity progress template")));
+});
+
+test("reports missing non-terminal call polling interval guidance", () => {
+  const { packageRoot, repoRoot } = createValidFixture(makeTempRoot("calle-codex-plugin-missing-polling"));
+  writeFile(
+    path.join(packageRoot, "plugin", "skills", "calle", "SKILL.md"),
+    "---\nname: calle\ndescription: Test skill.\n---\n\n# calle\n\nUse assistant_hint.message to include a brief post-auth help note after auth login.\n\nPhone call is in progress! Progress:\n\nDo not stay silent until a terminal status.\n",
+  );
+
+  const failures = checkCodexPlugin({ packageRoot, repoRoot });
+  assert.ok(failures.some((failure) => failure.includes("periodic polling")));
 });

--- a/packages/codex-plugin/test/check-plugin.test.js
+++ b/packages/codex-plugin/test/check-plugin.test.js
@@ -9,6 +9,16 @@ import { checkCodexPlugin } from "../scripts/check-plugin.mjs";
 
 const PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const REPO_ROOT = path.resolve(PACKAGE_ROOT, "../..");
+const VALID_AUTH_GUIDANCE =
+  "Use assistant_hint.message to include a brief post-auth help note after auth login.\n\n" +
+  "Run blocking `auth login` and keep the command running until it exits.\n\n" +
+  "do not ask the user to reply after browser authorization.\n\n" +
+  "Before we start, please complete authorization here\n\n" +
+  "Great, authorization is complete\n\n";
+const VALID_PROGRESS_GUIDANCE =
+  "Phone call is in progress! Progress:\n\n" +
+  "Do not stay silent until a terminal status.\n\n" +
+  "Poll every 10 seconds.\n";
 
 function writeJson(filePath, value) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -46,7 +56,7 @@ function createValidFixture(root) {
 
   writeFile(
     path.join(packageRoot, "plugin", "skills", "calle", "SKILL.md"),
-    "---\nname: calle\ndescription: Test skill.\n---\n\n# calle\n\nUse assistant_hint.message to include a brief post-auth help note after auth login.\n\nPhone call is in progress! Progress:\n\nDo not stay silent until a terminal status.\n\nPoll every 10 seconds.\n",
+    `---\nname: calle\ndescription: Test skill.\n---\n\n# calle\n\n${VALID_AUTH_GUIDANCE}${VALID_PROGRESS_GUIDANCE}`,
   );
   writeFile(
     path.join(packageRoot, "plugin", "skills", "calle", "agents", "openai.yaml"),
@@ -54,7 +64,7 @@ function createValidFixture(root) {
   );
   writeFile(
     path.join(packageRoot, "plugin", "skills", "calle", "references", "commands.md"),
-    "# Commands\n\nPhone call is in progress! Progress:\n\nWait 10 seconds.\n",
+    `# Commands\n\n${VALID_AUTH_GUIDANCE}Phone call is in progress! Progress:\n\nWait 10 seconds.\n`,
   );
 
   writeJson(path.join(repoRoot, ".agents", "plugins", "marketplace.json"), {
@@ -109,11 +119,25 @@ test("reports missing skill UI metadata", () => {
   assert.ok(failures.some((failure) => failure.includes("agents/openai.yaml")));
 });
 
+test("reports missing authorization guidance", () => {
+  const { packageRoot, repoRoot } = createValidFixture(makeTempRoot("calle-codex-plugin-missing-auth-guidance"));
+  writeFile(
+    path.join(packageRoot, "plugin", "skills", "calle", "SKILL.md"),
+    `---\nname: calle\ndescription: Test skill.\n---\n\n# calle\n\nUse assistant_hint.message to include a brief post-auth help note after auth login.\n\n${VALID_PROGRESS_GUIDANCE}`,
+  );
+
+  const failures = checkCodexPlugin({ packageRoot, repoRoot });
+  assert.ok(failures.some((failure) => failure.includes("blocking authorization")));
+  assert.ok(failures.some((failure) => failure.includes("manual chat reply")));
+  assert.ok(failures.some((failure) => failure.includes("first authorization help")));
+  assert.ok(failures.some((failure) => failure.includes("post-authorization success")));
+});
+
 test("reports missing non-terminal call progress guidance", () => {
   const { packageRoot, repoRoot } = createValidFixture(makeTempRoot("calle-codex-plugin-missing-progress"));
   writeFile(
     path.join(packageRoot, "plugin", "skills", "calle", "SKILL.md"),
-    "---\nname: calle\ndescription: Test skill.\n---\n\n# calle\n\nUse assistant_hint.message to include a brief post-auth help note after auth login.\n",
+    `---\nname: calle\ndescription: Test skill.\n---\n\n# calle\n\n${VALID_AUTH_GUIDANCE}`,
   );
 
   const failures = checkCodexPlugin({ packageRoot, repoRoot });
@@ -124,7 +148,7 @@ test("reports missing non-terminal call polling interval guidance", () => {
   const { packageRoot, repoRoot } = createValidFixture(makeTempRoot("calle-codex-plugin-missing-polling"));
   writeFile(
     path.join(packageRoot, "plugin", "skills", "calle", "SKILL.md"),
-    "---\nname: calle\ndescription: Test skill.\n---\n\n# calle\n\nUse assistant_hint.message to include a brief post-auth help note after auth login.\n\nPhone call is in progress! Progress:\n\nDo not stay silent until a terminal status.\n",
+    `---\nname: calle\ndescription: Test skill.\n---\n\n# calle\n\n${VALID_AUTH_GUIDANCE}Phone call is in progress! Progress:\n\nDo not stay silent until a terminal status.\n`,
   );
 
   const failures = checkCodexPlugin({ packageRoot, repoRoot });

--- a/packages/openclaw-cli-skill/skills/phone-call-calle/SKILL.md
+++ b/packages/openclaw-cli-skill/skills/phone-call-calle/SKILL.md
@@ -1,22 +1,17 @@
 ---
 name: Phone Call - Call-E
-description: New users get 20 free calls to get started. Make real outbound phone calls, run planned calls, and check call status in OpenClaw with Call-E through the calle CLI.
+description: New users get 20 free calls to get started. Make real outbound phone calls, run planned calls, and check call status in OpenClaw.
 license: MIT-0
 metadata: {"openclaw":{"requires":{"bins":["node"],"anyBins":["calle","npx"]},"install":[{"id":"call-e-cli","kind":"node","package":"@call-e/cli","bins":["calle"],"label":"Install Call-E CLI"}],"homepage":"https://github.com/CALLE-AI/call-e-integrations/tree/main/packages/openclaw-cli-skill"}}
 ---
 
 # Phone Call - Call-E
 
-Make real outbound phone calls, run planned calls, and check call status in
-OpenClaw with Call-E through the `calle` CLI.
+Make real outbound phone calls, continue active calls, and check call status with Call-E for OpenClaw.
 
 Use this skill when the user wants to call a phone number, make a phone call,
 place an outbound call, follow up by phone, call a business, call a customer,
-verify Call-E setup, recover Call-E authentication, or check the status,
-summary, details, and transcript of a call.
-
-This skill intentionally calls the CLI instead of depending on a native
-OpenClaw plugin or gateway-managed tool registration.
+or check the status, summary, details, and transcript of a call.
 
 ## When to use
 


### PR DESCRIPTION
## Summary
- add a start-only brokered auth login mode that returns login_url and pre-auth assistant guidance without polling
- include pending login details in auth status/auth_required payloads without leaking session secrets
- update Codex plugin authorization guidance and validation checks

## Verification
- pnpm --filter @call-e/cli test:e2e
- pnpm check
- pnpm pack:dry-run
- pnpm --filter @call-e/openagent test
- pnpm test