### PR TITLE
feat(skills-sh-skill): add portable calle skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Use the native release path when available:
 - OpenClaw: run `openclaw skills install phone-call-calle`.
 - Hermes Agent: open `https://clawhub.ai/call-e-dev/phone-call-calle`, choose Prompt, and paste the ClawHub install prompt into Hermes.
 - Codex: add the CALL-E plugin marketplace from `CALLE-AI/call-e-integrations` using the official Codex command in this README.
+- skills.sh compatible agents: install the `calle` skill from `packages/skills-sh-skill/skills/calle`.
 - CLI users: install `@call-e/cli`, then run `calle auth login`.
 - MCP-only clients: use Streamable HTTP with `https://seleven-mcp-sg.airudder.com/mcp/openagent_oauth`.
 
@@ -67,6 +68,17 @@ Then open Codex → `/plugins` → choose the `CALL-E` marketplace → install `
 ```text
 $calle
 ```
+
+### skills.sh
+
+Install the portable `calle` skill with the skills CLI:
+
+```bash
+npx skills add https://github.com/CALLE-AI/call-e-integrations/tree/main/packages/skills-sh-skill/skills/calle -a codex
+```
+
+Use another supported `-a <agent>` value when installing for a different
+skills.sh compatible agent.
 
 ### Claude Code
 
@@ -190,8 +202,9 @@ Then complete the client OAuth flow and verify the available tools include `plan
 - OpenClaw user installs should use ClawHub: `openclaw skills install phone-call-calle`.
 - Hermes Agent user installs should use the ClawHub Prompt flow from the same skill page; this repository does not publish a separate Hermes plugin.
 - This repository keeps the OpenClaw skill source at `packages/openclaw-cli-skill/skills/phone-call-calle` for local development and validation.
+- skills.sh compatible installs should use the direct GitHub tree path for `packages/skills-sh-skill/skills/calle`.
 
-Install guides: [CLI](./docs/install/cli.md) · [Codex](./docs/install/codex-plugin.md) · [Claude Code](./docs/install/claude-plugin.md) · [Cursor MCP](./docs/install/cursor.md) · [Cursor plugin](./docs/install/cursor-plugin.md) · [OpenClaw source](./docs/install/openclaw-cli-skill.md)
+Install guides: [CLI](./docs/install/cli.md) · [Codex](./docs/install/codex-plugin.md) · [skills.sh](./docs/install/skills-sh-skill.md) · [Claude Code](./docs/install/claude-plugin.md) · [Cursor MCP](./docs/install/cursor.md) · [Cursor plugin](./docs/install/cursor-plugin.md) · [OpenClaw source](./docs/install/openclaw-cli-skill.md)
 
 </details>
 
@@ -210,7 +223,7 @@ plan_call → run_call → get_call_run
 | Call planning | `calle call plan` or MCP `plan_call` |
 | Real outbound call execution | `calle call run` or MCP `run_call` |
 | Status, activity, summary, details, transcript | `calle call status` or MCP `get_call_run` |
-| Agent-client UX | `$calle` in Codex; `/calle:calle` in Claude Code; `calle` MCP/skill in Cursor; **Phone Call - CALL-E** in OpenClaw; ClawHub Prompt flow in Hermes Agent |
+| Agent-client UX | `$calle` in Codex; `calle` through skills.sh; `/calle:calle` in Claude Code; `calle` MCP/skill in Cursor; **Phone Call - CALL-E** in OpenClaw; ClawHub Prompt flow in Hermes Agent |
 
 `plan_call` creates the call plan and returns run credentials. `run_call` starts the real outbound call. `get_call_run` returns progress and final results when available.
 
@@ -261,6 +274,7 @@ All command output is JSON except `--help`. Access tokens are read from the loca
 | `packages/claude-plugin` | `@call-e/claude-plugin` | Claude Code plugin bundle that exposes CALL-E through the shared CLI and `/calle:calle`. |
 | `packages/cursor-plugin` | `@call-e/cursor-plugin` | Cursor plugin bundle that exposes CALL-E through MCP, a `calle` skill, and a safety rule. |
 | `packages/openclaw-cli-skill` | `@call-e/openclaw-cli-skill` | Private validation/source package for the OpenClaw skill published through ClawHub. |
+| `packages/skills-sh-skill` | `@call-e/skills-sh-skill` | Private validation/source package for the portable skills.sh `calle` skill. |
 
 ```text
 .agents/plugins/marketplace.json              # Codex marketplace entry
@@ -270,6 +284,7 @@ packages/codex-plugin/plugin/                 # Codex plugin source
 packages/claude-plugin/plugin/                # Claude Code plugin source
 packages/cursor-plugin/plugin/                # Cursor plugin source
 packages/openclaw-cli-skill/skills/            # OpenClaw skill source
+packages/skills-sh-skill/skills/               # skills.sh compatible skill source
 packages/cli/                                  # Shared calle CLI
 packages/core/                                 # Shared runtime helpers
 examples/                                      # Runnable MCP demos, not an SDK
@@ -295,6 +310,9 @@ examples/                                      # Runnable MCP demos, not an SDK
 | Cursor CLI attribution | env | `cursor/cursor_plugin/<version>` |
 | OpenClaw skill | slug | `phone-call-calle` |
 | OpenClaw skill | name | `Phone Call - CALL-E` |
+| skills.sh skill | name | `calle` |
+| skills.sh skill source | path | `packages/skills-sh-skill/skills/calle` |
+| skills.sh CLI attribution | env | `skills_sh/skills_sh_skill/<version>` |
 
 ## 🧪 Examples
 
@@ -308,7 +326,7 @@ These examples are runnable demos, not a CALL-E SDK or supported application API
 ## 🧭 Boundaries
 
 - The CLI is not an OAuth server and not an MCP server. It is a local wrapper over the CALL-E broker API and remote MCP HTTP endpoint.
-- Codex, Claude Code, OpenClaw, and Hermes Agent integrations intentionally reuse the shared `calle` CLI for authentication, token caching, JSON output, MCP tool discovery, and call workflow shortcuts.
+- Codex, Claude Code, OpenClaw, skills.sh, and Hermes Agent integrations intentionally reuse the shared `calle` CLI for authentication, token caching, JSON output, MCP tool discovery, and call workflow shortcuts.
 - The Cursor plugin reuses the existing remote CALL-E MCP server and does not implement a new local MCP server or backend.
 - The OpenClaw route in this repository does not register OpenClaw-native tools and does not require a gateway restart from this repository.
 - Hermes Agent support uses the ClawHub Prompt flow for the published OpenClaw skill; this repository does not maintain a separate Hermes plugin.
@@ -320,7 +338,7 @@ See [docs/agent-integration-layout.md](./docs/agent-integration-layout.md) for l
 
 The `calle` CLI sends best-effort usage telemetry to CALL-E to diagnose installation, authentication, MCP tool availability, and early usage drop-off before a first `plan_call` reaches the server.
 
-CLI telemetry includes an anonymous installation ID, CLI version, integration source such as `cli/cli/<version>`, `codex/codex_plugin/<version>`, `claude/claude_code_plugin/<version>`, `cursor/cursor_plugin/<version>`, or `openclaw/openclaw_cli_skill/<version>`, command stage, outcome, error type, and server host/hash. It does **not** include phone numbers, call goals, OAuth tokens, broker login URLs, full argument JSON, transcripts, or contact data.
+CLI telemetry includes an anonymous installation ID, CLI version, integration source such as `cli/cli/<version>`, `codex/codex_plugin/<version>`, `claude/claude_code_plugin/<version>`, `cursor/cursor_plugin/<version>`, `openclaw/openclaw_cli_skill/<version>`, or `skills_sh/skills_sh_skill/<version>`, command stage, outcome, error type, and server host/hash. It does **not** include phone numbers, call goals, OAuth tokens, broker login URLs, full argument JSON, transcripts, or contact data.
 
 Disable CLI telemetry with any of:
 
@@ -358,6 +376,8 @@ pnpm --filter @call-e/cursor-plugin check
 pnpm --filter @call-e/cursor-plugin test
 pnpm --filter @call-e/openclaw-cli-skill check
 pnpm --filter @call-e/openclaw-cli-skill test
+pnpm --filter @call-e/skills-sh-skill check
+pnpm --filter @call-e/skills-sh-skill test
 pnpm run check:examples
 ```
 

--- a/docs/agent-integration-layout.md
+++ b/docs/agent-integration-layout.md
@@ -25,6 +25,12 @@ Current OpenClaw layout:
 packages/openclaw-cli-skill/skills/
 ```
 
+Current skills.sh layout:
+
+```text
+packages/skills-sh-skill/skills/
+```
+
 Current Claude Code layout:
 
 ```text
@@ -40,6 +46,8 @@ packages/cursor-plugin/plugin/
 ```
 
 Use `packages/openclaw-cli-skill/skills/` for the OpenClaw CALL-E skill source.
+Use `packages/skills-sh-skill/skills/` for the skills.sh compatible CALL-E
+skill source.
 Use `.agents/skills/` for repository-local Codex helper skills. Do not put
 productized client-specific skill packages there; keep them under their owning
 package.
@@ -76,6 +84,14 @@ For Cursor:
 - The Cursor MCP server key must stay `calle`.
 - The Cursor CLI fallback attribution must stay
   `cursor/cursor_plugin/<version>`.
+
+For skills.sh:
+
+- The skills.sh package path must stay `packages/skills-sh-skill`.
+- The skills.sh skill directory must stay `packages/skills-sh-skill/skills/calle`.
+- The skills.sh skill frontmatter `name` must stay `calle`.
+- The skills.sh CLI integration attribution must stay
+  `skills_sh/skills_sh_skill/<version>`.
 
 Use ecosystem-specific internal marketplace names when adding other clients:
 
@@ -201,3 +217,18 @@ packages/cursor-plugin/plugin/
 The plugin bundles the same remote MCP server with a `calle` skill and an
 always-on real-call safety rule. It is prepared for Cursor Marketplace
 submission; publication is a separate operational step.
+
+skills.sh install example:
+
+Use the direct GitHub tree path so `skills` installs only the portable `calle`
+skill and does not discover repository-local helper skills:
+
+```bash
+npx skills add https://github.com/CALLE-AI/call-e-integrations/tree/main/packages/skills-sh-skill/skills/calle -a codex
+```
+
+Or install from the skills package directory and select `calle`:
+
+```bash
+npx skills add https://github.com/CALLE-AI/call-e-integrations/tree/main/packages/skills-sh-skill/skills --skill calle -a codex
+```

--- a/docs/install/skills-sh-skill.md
+++ b/docs/install/skills-sh-skill.md
@@ -1,0 +1,51 @@
+# Install The CALL-E skills.sh Skill
+
+The skills.sh compatible integration path in this repository is the `calle`
+skill at `packages/skills-sh-skill/skills/calle`. It teaches any compatible
+agent to use CALL-E through the shared `calle` CLI.
+
+## Install From GitHub
+
+Install the direct skill path:
+
+```bash
+npx skills add https://github.com/CALLE-AI/call-e-integrations/tree/main/packages/skills-sh-skill/skills/calle -a codex
+```
+
+Or install from the package skills directory and select `calle`:
+
+```bash
+npx skills add https://github.com/CALLE-AI/call-e-integrations/tree/main/packages/skills-sh-skill/skills --skill calle -a codex
+```
+
+Replace `codex` with another supported agent when needed.
+
+## CLI Availability
+
+The skill uses the repository-local CLI when available, then a global `calle`
+command when available, then falls back to:
+
+```bash
+npx -y @call-e/cli@0.3.2
+```
+
+To authenticate before using the skill:
+
+```bash
+npx -y @call-e/cli@0.3.2 auth login
+```
+
+## Verify The Package
+
+```bash
+pnpm --filter @call-e/skills-sh-skill check
+pnpm --filter @call-e/skills-sh-skill test
+pnpm --filter @call-e/skills-sh-skill pack:dry-run
+npx -y skills-ref validate ./packages/skills-sh-skill/skills/calle
+npx -y skills add ./packages/skills-sh-skill/skills/calle --list
+```
+
+## More
+
+See [packages/skills-sh-skill/README.md](../../packages/skills-sh-skill/README.md)
+for package layout, safety notes, and validation commands.

--- a/packages/skills-sh-skill/README.md
+++ b/packages/skills-sh-skill/README.md
@@ -1,0 +1,42 @@
+# @call-e/skills-sh-skill
+
+skills.sh compatible CALL-E skill for making real outbound phone calls,
+running planned calls, and checking call status through the `calle` CLI.
+
+For setup steps, see
+[docs/install/skills-sh-skill.md](../../docs/install/skills-sh-skill.md).
+
+## Layout
+
+```text
+skills/
+  calle/
+    SKILL.md
+    agents/
+      openai.yaml
+    references/
+      commands.md
+```
+
+## Local Validation
+
+From the repository root:
+
+```bash
+pnpm --filter @call-e/skills-sh-skill check
+pnpm --filter @call-e/skills-sh-skill test
+pnpm --filter @call-e/skills-sh-skill pack:dry-run
+npx -y skills-ref validate ./packages/skills-sh-skill/skills/calle
+npx -y skills add ./packages/skills-sh-skill/skills/calle --list
+```
+
+## CLI Selection
+
+The skill uses the repository-local CLI when available, then a global `calle`
+command when available, then falls back to `npx -y @call-e/cli@0.3.2`.
+
+## Safety
+
+CALL-E can place real phone calls. The skill always plans first, uses returned
+credentials exactly as provided, and does not place a call unless the user
+clearly intends to do so.

--- a/packages/skills-sh-skill/package.json
+++ b/packages/skills-sh-skill/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@call-e/skills-sh-skill",
+  "version": "0.1.0",
+  "description": "skills.sh compatible CALL-E skill for outbound phone calls through the calle CLI.",
+  "type": "module",
+  "private": true,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/CALLE-AI/call-e-integrations.git",
+    "directory": "packages/skills-sh-skill"
+  },
+  "homepage": "https://github.com/CALLE-AI/call-e-integrations/tree/main/packages/skills-sh-skill",
+  "bugs": {
+    "url": "https://github.com/CALLE-AI/call-e-integrations/issues"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "files": [
+    "README.md",
+    "skills"
+  ],
+  "keywords": [
+    "ai-agent",
+    "calle",
+    "call-e",
+    "skills-sh",
+    "agent-skills",
+    "skill",
+    "cli",
+    "mcp",
+    "phone-call",
+    "outbound-call",
+    "call-status",
+    "voice-call"
+  ],
+  "scripts": {
+    "check": "node ./scripts/check-skill.mjs",
+    "test": "node --test ./test/*.test.js",
+    "pack:dry-run": "npm pack --dry-run"
+  }
+}

--- a/packages/skills-sh-skill/scripts/check-skill.mjs
+++ b/packages/skills-sh-skill/scripts/check-skill.mjs
@@ -1,0 +1,224 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_PACKAGE_ROOT = path.resolve(SCRIPT_DIR, "..");
+const DEFAULT_REPO_ROOT = path.resolve(DEFAULT_PACKAGE_ROOT, "../..");
+
+const EXPECTED_PACKAGE_NAME = "@call-e/skills-sh-skill";
+const EXPECTED_SKILL_DIR = "calle";
+const EXPECTED_SKILL_NAME = "calle";
+const EXPECTED_SOURCE = "CALLE_SOURCE=skills_sh";
+const EXPECTED_INTEGRATION = "CALLE_INTEGRATION=skills_sh_skill";
+
+function readJson(filePath, failures) {
+  if (!fs.existsSync(filePath)) {
+    failures.push(`Missing ${filePath}`);
+    return null;
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (error) {
+    failures.push(`Invalid JSON at ${filePath}: ${error.message}`);
+    return null;
+  }
+}
+
+function assert(condition, failures, message) {
+  if (!condition) {
+    failures.push(message);
+  }
+}
+
+function extractFrontmatter(markdown) {
+  const match = /^---\n([\s\S]*?)\n---\n?/u.exec(markdown);
+  return match ? match[1] : null;
+}
+
+function frontmatterValue(frontmatter, key) {
+  const match = new RegExp(`^${key}:\\s*([^\\n]+)\\s*$`, "mu").exec(frontmatter);
+  return match?.[1]?.trim().replace(/^['"]|['"]$/g, "") ?? null;
+}
+
+function frontmatterKeys(frontmatter) {
+  return [...frontmatter.matchAll(/^([A-Za-z0-9_-]+):/gmu)].map((match) => match[1]);
+}
+
+function assertRequiredSnippets({ source, filePath, snippets, failures }) {
+  for (const snippet of snippets) {
+    if (!snippet) {
+      continue;
+    }
+
+    assert(source.includes(snippet), failures, `${filePath} must include ${snippet}.`);
+  }
+}
+
+function integrationVersionSnippet(packageJson) {
+  return typeof packageJson?.version === "string" && packageJson.version.length > 0
+    ? `CALLE_INTEGRATION_VERSION=${packageJson.version}`
+    : null;
+}
+
+function checkPackage({ packageRoot, failures }) {
+  const packageJsonPath = path.join(packageRoot, "package.json");
+  const packageJson = readJson(packageJsonPath, failures);
+  if (!packageJson) {
+    return null;
+  }
+
+  assert(packageJson.name === EXPECTED_PACKAGE_NAME, failures, "package.json name must be @call-e/skills-sh-skill.");
+  assert(typeof packageJson.version === "string" && packageJson.version.length > 0, failures, "package.json must include a version.");
+  assert(packageJson.private === true, failures, "package.json must keep this validation package private.");
+  assert(packageJson.files?.includes("README.md"), failures, "package.json files must include README.md.");
+  assert(packageJson.files?.includes("skills"), failures, "package.json files must include skills.");
+  assert(packageJson.scripts?.check === "node ./scripts/check-skill.mjs", failures, "package.json must expose the package check script.");
+  assert(packageJson.scripts?.test, failures, "package.json must expose a test script.");
+  assert(packageJson.scripts?.["pack:dry-run"], failures, "package.json must expose a pack:dry-run script.");
+
+  return packageJson;
+}
+
+function checkSkill({ packageRoot, packageJson, failures }) {
+  const skillDir = path.join(packageRoot, "skills", EXPECTED_SKILL_DIR);
+  const skillFile = path.join(skillDir, "SKILL.md");
+  const skillInterfaceFile = path.join(skillDir, "agents", "openai.yaml");
+  const referenceFile = path.join(skillDir, "references", "commands.md");
+  const expectedVersion = integrationVersionSnippet(packageJson);
+
+  assert(fs.existsSync(skillDir), failures, `Missing skill directory: ${skillDir}`);
+  assert(fs.existsSync(skillFile), failures, `Missing skill file: ${skillFile}`);
+  assert(fs.existsSync(skillInterfaceFile), failures, `Missing skill UI metadata: ${skillInterfaceFile}`);
+  assert(fs.existsSync(referenceFile), failures, `Missing command reference: ${referenceFile}`);
+
+  if (!fs.existsSync(skillFile)) {
+    return;
+  }
+
+  const source = fs.readFileSync(skillFile, "utf8");
+  const frontmatter = extractFrontmatter(source);
+  assert(frontmatter, failures, `${skillFile} must start with YAML frontmatter.`);
+  assert(!source.includes("[TODO:"), failures, `${skillFile} must not contain template TODO markers.`);
+
+  assertRequiredSnippets({
+    source,
+    filePath: skillFile,
+    failures,
+    snippets: [
+      EXPECTED_SOURCE,
+      EXPECTED_INTEGRATION,
+      expectedVersion,
+      "npx -y @call-e/cli@",
+      "assistant_hint.message",
+      "auth_required",
+      "auth login --start-only --no-browser-open",
+      "authorization instructions returned by the CLI",
+      "auth login --no-browser-open",
+      "Great, authorization is complete",
+      "call plan",
+      "call run",
+      "call status",
+      "Phone call is in progress! Progress:",
+      "do not use `run_result`",
+      "status_result.structuredContent",
+      "Never paraphrase call results",
+      "the entire reply must be exactly this shape",
+      "Poll every 10 seconds",
+    ],
+  });
+
+  if (frontmatter) {
+    const keys = frontmatterKeys(frontmatter);
+    const unexpectedKeys = keys.filter((key) => !["name", "description"].includes(key));
+    assert(unexpectedKeys.length === 0, failures, `${skillFile} frontmatter must only include name and description.`);
+    assert(frontmatterValue(frontmatter, "name") === EXPECTED_SKILL_NAME, failures, `${skillFile} frontmatter name must be "${EXPECTED_SKILL_NAME}".`);
+    assert(Boolean(frontmatterValue(frontmatter, "description")), failures, `${skillFile} frontmatter must include description.`);
+  }
+
+  if (fs.existsSync(skillInterfaceFile)) {
+    const skillInterfaceSource = fs.readFileSync(skillInterfaceFile, "utf8");
+    assert(/display_name:\s*"calle"/u.test(skillInterfaceSource), failures, `${skillInterfaceFile} must set interface.display_name to "calle".`);
+    assert(skillInterfaceSource.includes("Use $calle"), failures, `${skillInterfaceFile} default_prompt must mention $calle.`);
+  }
+
+  if (!fs.existsSync(referenceFile)) {
+    return;
+  }
+
+  const referenceSource = fs.readFileSync(referenceFile, "utf8");
+  assertRequiredSnippets({
+    source: referenceSource,
+    filePath: referenceFile,
+    failures,
+    snippets: [
+      EXPECTED_SOURCE,
+      EXPECTED_INTEGRATION,
+      expectedVersion,
+      "npx -y @call-e/cli@",
+      "assistant_hint.message",
+      "auth_required",
+      "auth login --start-only --no-browser-open",
+      "authorization instructions returned by the CLI",
+      "auth login --no-browser-open",
+      "Great, authorization is complete",
+      "call plan",
+      "call run",
+      "call status",
+      "Phone call is in progress! Progress:",
+      "run_result",
+      "status_result.structuredContent",
+      "Never paraphrase call results",
+      "the entire reply must be exactly this shape",
+      "Wait 10 seconds",
+    ],
+  });
+}
+
+function checkRepoDocs({ repoRoot, failures }) {
+  const readmePath = path.join(repoRoot, "README.md");
+  const installDocPath = path.join(repoRoot, "docs", "install", "skills-sh-skill.md");
+  const layoutPath = path.join(repoRoot, "docs", "agent-integration-layout.md");
+
+  assert(fs.existsSync(installDocPath), failures, `Missing install guide: ${installDocPath}`);
+
+  if (fs.existsSync(readmePath)) {
+    const readme = fs.readFileSync(readmePath, "utf8");
+    assert(readme.includes("packages/skills-sh-skill"), failures, "README.md must mention packages/skills-sh-skill.");
+    assert(readme.includes("docs/install/skills-sh-skill.md"), failures, "README.md must link to the skills.sh install guide.");
+  }
+
+  if (fs.existsSync(layoutPath)) {
+    const layout = fs.readFileSync(layoutPath, "utf8");
+    assert(layout.includes("packages/skills-sh-skill"), failures, "docs/agent-integration-layout.md must mention packages/skills-sh-skill.");
+    assert(layout.includes("skills.sh"), failures, "docs/agent-integration-layout.md must describe the skills.sh skill boundary.");
+  }
+}
+
+export function checkSkillsShSkill({
+  packageRoot = DEFAULT_PACKAGE_ROOT,
+  repoRoot = DEFAULT_REPO_ROOT,
+} = {}) {
+  const failures = [];
+  const packageJson = checkPackage({ packageRoot, failures });
+  checkSkill({ packageRoot, packageJson, failures });
+  checkRepoDocs({ repoRoot, failures });
+  return failures;
+}
+
+function main() {
+  const failures = checkSkillsShSkill();
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      console.error(failure);
+    }
+    process.exit(1);
+  }
+
+  console.log("CALL-E skills.sh skill metadata is valid.");
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/packages/skills-sh-skill/skills/calle/SKILL.md
+++ b/packages/skills-sh-skill/skills/calle/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: calle
+description: Use CALL-E from skills.sh compatible agents through the calle CLI. Use for CALL-E setup checks, authentication recovery, phone call planning, placing real outbound calls, planned call execution, call status polling, summaries, details, and transcripts.
+---
+
+# calle
+
+Use CALL-E from skills.sh compatible agents through the shared `calle` CLI.
+
+CALL-E can place real outbound phone calls. Always plan first, preserve returned
+credentials exactly, and only run a planned call when the user clearly intends
+to place that call.
+
+## Safety
+
+- Real calls may contact external people or businesses.
+- Do not place a real call unless the user clearly intends to do so.
+- Always run `call plan` before `call run`.
+- If the user asked to place a call, run it immediately after planning returns
+  a valid `plan_id` and `confirm_token`.
+- If the user asked only to verify setup or only to plan, do not run the call.
+- Do not guess phone numbers, country codes, language, region, `plan_id`,
+  `confirm_token`, or `run_id`.
+- Do not print, request, or expose access tokens.
+
+## CLI Selection
+
+All CLI commands run from this skill must include the CALL-E integration
+attribution environment:
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0
+```
+
+Use the first command form that works.
+
+Prefer the repository-local CLI when the current workspace contains it:
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 node packages/cli/bin/calle.js
+```
+
+If the repository-local CLI is unavailable, use the global command:
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle
+```
+
+If neither command works, use the pinned npm package through `npx`:
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 npx -y @call-e/cli@0.3.2
+```
+
+Only tell the user to install the CLI globally if `npx` is unavailable,
+network access is blocked, or the user explicitly wants a persistent global
+command.
+
+## Readiness Flow
+
+Use this flow whenever this skill is actively invoked for a CALL-E request. Run
+it before call planning, before tool listing, when setup is uncertain, when
+auth fails, or when the user asks to verify CALL-E setup:
+
+1. Check CLI availability with `--help`.
+2. Run `auth status`.
+3. If `auth status` reports `usable: false`, do not continue to call planning
+   or `mcp tools` yet. Run `auth login --start-only --no-browser-open` to
+   create or reuse a brokered login session and return CLI-provided
+   authorization instructions without opening a browser inside the current
+   agent turn.
+4. Show the CLI-provided `assistant_hint.message` when it is present. If it is
+   absent, tell the user that authentication is required, ask them to follow
+   the authorization instructions returned by the CLI, and stop the current
+   workflow until they confirm authorization is complete. Do not invent or
+   rewrite authorization URLs, and never ask for credentials, secrets, or
+   tokens.
+5. When the user confirms browser authorization is complete, run
+   `auth login --no-browser-open` to poll the existing pending login, exchange
+   the authorized session, and write the local token cache.
+6. If the successful `auth login --no-browser-open` JSON included
+   `assistant_hint.message`, show that post-auth success message in the next
+   user-facing reply. If the user already gave a call goal, continue the
+   original workflow after the message; otherwise ask for the phone number and
+   call goal, or offer a test call.
+7. After login completes, run `mcp tools`.
+8. Confirm that `plan_call`, `run_call`, and `get_call_run` are available.
+
+Setup verification must not place a real phone call. Use only help, auth, and
+tool-listing commands until the user asks for a call workflow.
+
+Post-authorization success template:
+
+```text
+Great, authorization is complete
+
+- If you already shared the call goal, I'll continue as planned.
+- If you haven't, that's okay. I can help you place a test call first, or start a real call directly.
+
+You can tell me:
+- Your phone number: Used only for this service. We will not disclose it to anyone else, including the callee.
+- What you want me to say: For example, "This is a test call from CALL-E. Wishing you a good day, and asking if there's anything you'd like to share."
+
+I'll keep you updated on the phone status, call content, and summary.
+```
+
+## Call Flow
+
+1. Use `call plan` first.
+2. Read the returned `plan_id` and `confirm_token`.
+3. If the user's request is to place a call, immediately use `call run` with
+   the exact `plan_id` and `confirm_token` returned by planning.
+4. Do not ask for a second confirmation between `call plan` and `call run`.
+5. Read the returned `run_id` and latest call status. In `call run` output, the
+   latest call state is in `status_result.structuredContent`. In `call status`
+   output, the latest call state is in `result.structuredContent`.
+6. After `call run`, do not use `run_result` for the user-visible reply except
+   to preserve the returned `run_id`. Treat `status_result.structuredContent`
+   as the latest `get_call_run` result and base the user-visible reply on that
+   object.
+7. After `call status`, treat `result.structuredContent` as the latest
+   `get_call_run` result and base the user-visible reply on that object.
+8. If the latest status is not terminal, immediately show a user-visible
+   progress update from the latest activity data before polling again. Use
+   `status_result.structuredContent.activity` after `call run`, or
+   `result.structuredContent.activity` after `call status`.
+9. Keep using `call status` with that exact `run_id` until the call reaches a
+   terminal status or the user asks you to stop. Poll every 10 seconds: after
+   each non-terminal response, show the latest activity progress, wait 10
+   seconds, then fetch `call status` again. Do not stay silent until a terminal
+   status.
+10. Use `call status` only with a known `run_id`.
+
+If any command returns `auth_required`, switch to the readiness flow, complete
+login, and then retry the original operation after login completes.
+
+Never paraphrase call results into free-form prose such as
+`The call succeeded. Result: ...`. Do not translate the headings, do not add
+extra commentary, and do not wrap the result in code fences.
+
+For non-terminal statuses, the entire reply must be exactly this shape:
+
+```text
+Phone call is in progress! Progress:
+- <HH:MM:SS message>
+```
+
+Use one bullet per `activity` item, preserving the order returned by the CLI.
+For each item, prefer the event `ts` formatted as `HH:MM:SS` plus `message`.
+If `ts` is missing, use the message by itself. If there is no activity, use
+`- <message>` when `message` exists, otherwise use `- Status: <status>` when a
+status exists, otherwise use `- Waiting for the next status update.` Do not
+include the final summary, details, or transcript until a terminal status is
+returned.
+
+Terminal statuses include `COMPLETED`, `FAILED`, `NO_ANSWER`, `DECLINED`,
+`CANCELED`, `CANCELLED`, `VOICEMAIL`, `BUSY`, and `EXPIRED`.
+
+When the call reaches a terminal status, reply with the final call result,
+including these sections in this order:
+
+```text
+[Status]
+<status>
+
+[Call Summary]
+<post_summary or summary or message>
+
+[Details]
+Callee Number: <primary callee or Not available>
+Duration: <duration or Not available>
+Time: <start/end time or Not available>
+Call id: <call_id or Not available>
+
+[Transcript]
+<transcript or Not available.>
+```
+
+If the user asked for extra final content, such as key takeaways or next steps,
+add it after `[Transcript]` under a short heading. Base all final sections only
+on the JSON returned by `call run` or `call status`; do not invent a transcript.
+
+Use `references/commands.md` for exact command examples, supported options, and
+JSON handling rules.
+
+## Community
+
+For installation help, rollout updates, and feedback:
+
+- Discord: https://discord.gg/6AbXUzUV8w

--- a/packages/skills-sh-skill/skills/calle/agents/openai.yaml
+++ b/packages/skills-sh-skill/skills/calle/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "calle"
+  short_description: "CALL-E phone calls from agent skills"
+  default_prompt: "Use $calle to place or check a CALL-E phone call."

--- a/packages/skills-sh-skill/skills/calle/references/commands.md
+++ b/packages/skills-sh-skill/skills/calle/references/commands.md
@@ -1,0 +1,231 @@
+# CALL-E CLI commands
+
+Use the first command form that is available in the current workspace.
+
+Repository-local base command:
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 node packages/cli/bin/calle.js
+```
+
+Global base command:
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle
+```
+
+npx fallback base command:
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 npx -y @call-e/cli@0.3.2
+```
+
+## Setup and readiness
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 node packages/cli/bin/calle.js --help
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 node packages/cli/bin/calle.js auth status
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 node packages/cli/bin/calle.js auth login --start-only --no-browser-open
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 node packages/cli/bin/calle.js auth login --no-browser-open
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 node packages/cli/bin/calle.js mcp tools
+```
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle --help
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle auth status
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle auth login --start-only --no-browser-open
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle auth login --no-browser-open
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle mcp tools
+```
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 npx -y @call-e/cli@0.3.2 --help
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 npx -y @call-e/cli@0.3.2 auth status
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 npx -y @call-e/cli@0.3.2 auth login --start-only --no-browser-open
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 npx -y @call-e/cli@0.3.2 auth login --no-browser-open
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 npx -y @call-e/cli@0.3.2 mcp tools
+```
+
+Rules:
+
+- Treat all command output as JSON except `--help`.
+- Do not print or ask for access tokens.
+- Whenever this skill is actively invoked, run `auth status` before call
+  planning or tool listing.
+- If `auth status` reports `usable: false`, do not call `mcp tools` or
+  `call plan` yet. Run `auth login --start-only --no-browser-open` to create
+  or reuse a brokered login session and return CLI-provided authorization
+  instructions without opening a browser inside the current agent turn.
+- Show the CLI-provided `assistant_hint.message` when it is present. If it is
+  absent, tell the user that authentication is required, ask them to follow the
+  authorization instructions returned by the CLI, and stop the current workflow
+  until they confirm authorization is complete.
+- Do not invent or rewrite authorization URLs, and never ask for credentials,
+  secrets, or tokens.
+- When the user confirms browser authorization is complete, run
+  `auth login --no-browser-open` to poll the existing pending login, exchange
+  the authorized session, and write the local token cache.
+- If successful `auth login --no-browser-open` output includes
+  `assistant_hint.message`, show it as the post-authorization success note.
+  Then continue the original call workflow if the user already gave enough
+  details.
+- If a command returns `auth_required`, switch back to this auth flow.
+- If `mcp tools` succeeds, confirm that `plan_call`, `run_call`, and
+  `get_call_run` are present.
+- Do not run `call run` during setup verification.
+- Do not use raw HTTP or direct remote MCP configuration in this skill.
+
+Post-authorization success template:
+
+```text
+Great, authorization is complete
+
+- If you already shared the call goal, I'll continue as planned.
+- If you haven't, that's okay. I can help you place a test call first, or start a real call directly.
+
+You can tell me:
+- Your phone number: Used only for this service. We will not disclose it to anyone else, including the callee.
+- What you want me to say: For example, "This is a test call from CALL-E. Wishing you a good day, and asking if there's anything you'd like to share."
+
+I'll keep you updated on the phone status, call content, and summary.
+```
+
+## Call planning
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 node packages/cli/bin/calle.js call plan --to-phone +15551234567 --goal "Confirm the appointment"
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle call plan --to-phone +15551234567 --goal "Confirm the appointment"
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 npx -y @call-e/cli@0.3.2 call plan --to-phone +15551234567 --goal "Confirm the appointment"
+```
+
+Supported `call plan` options:
+
+- `--to-phone <phone>` repeatable
+- `--goal <text>`
+- `--language <language>`
+- `--region <region>`
+
+Only provide options when the value is explicitly known. Do not infer missing
+phone numbers, country codes, language, or region.
+
+## Planned call execution
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 node packages/cli/bin/calle.js call run --plan-id <plan_id> --confirm-token <confirm_token>
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle call run --plan-id <plan_id> --confirm-token <confirm_token>
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 npx -y @call-e/cli@0.3.2 call run --plan-id <plan_id> --confirm-token <confirm_token>
+```
+
+Supported `call run` options:
+
+- `--plan-id <id>`
+- `--confirm-token <token>`
+
+Run this command immediately after planning returns a valid `plan_id` and
+`confirm_token`, when the user's request is to place a call. Preserve `plan_id`
+and `confirm_token` exactly as returned by planning.
+
+`call run` calls `run_call`, then fetches `get_call_run` once. Do not use
+`run_result` for the user-visible reply except to preserve the returned
+`run_id`. Treat `status_result.structuredContent` as the latest
+`get_call_run` result. If that status is not terminal, show a user-visible
+progress update from `status_result.structuredContent.activity` immediately,
+then continue with `call status --run-id <run_id>` every 10 seconds until a
+terminal status is returned or the user asks you to stop.
+
+## Call status
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 node packages/cli/bin/calle.js call status --run-id <run_id>
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle call status --run-id <run_id>
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 npx -y @call-e/cli@0.3.2 call status --run-id <run_id>
+```
+
+Supported `call status` options:
+
+- `--run-id <id>`
+- `--cursor <cursor>`
+- `--limit <number>`
+
+Use status commands only with a known `run_id`.
+
+Terminal statuses:
+
+- `COMPLETED`
+- `FAILED`
+- `NO_ANSWER`
+- `DECLINED`
+- `CANCELED`
+- `CANCELLED`
+- `VOICEMAIL`
+- `BUSY`
+- `EXPIRED`
+
+Read call data from `status_result.structuredContent` in `call run` output, or
+from `result.structuredContent` in `call status` output.
+
+Never paraphrase call results into free-form prose such as
+`The call succeeded. Result: ...`. Do not translate the headings, do not add
+extra commentary, and do not wrap the result in code fences.
+
+For `call run`, base the user-visible reply on
+`status_result.structuredContent`. For `call status`, base the user-visible
+reply on `result.structuredContent`.
+
+For non-terminal statuses, the entire reply must be exactly this shape:
+
+```text
+Phone call is in progress! Progress:
+- <HH:MM:SS message>
+```
+
+Use one bullet per `activity` item, preserving the order returned by the CLI.
+For `call run`, read activity from `status_result.structuredContent.activity`.
+For `call status`, read activity from `result.structuredContent.activity`.
+For each activity item, prefer the event `ts` formatted as `HH:MM:SS` plus
+`message`. If `ts` is missing, use the message by itself. If there is no
+activity, use `- <message>` when `message` exists, otherwise use
+`- Status: <status>` when a status exists, otherwise use
+`- Waiting for the next status update.` Do not wait silently for the terminal
+result.
+
+Polling cadence:
+
+1. Show the latest non-terminal progress.
+2. Wait 10 seconds.
+3. Run `call status --run-id <run_id>`.
+4. If the status is still non-terminal, show the new activity and repeat.
+5. Stop polling when a terminal status is returned, the user asks you to stop,
+   or command execution is interrupted.
+
+For terminal statuses, include the final transcript in the user-visible reply:
+
+```text
+[Status]
+<status>
+
+[Call Summary]
+<result.post_summary or result.summary or message>
+
+[Details]
+Callee Number: <result.extracted.to_phones[0] or result.extracted.calling.callee or Not available>
+Duration: <result.extracted.calling.duration_seconds or Not available>
+Time: <result.extracted.calling.started_at and ended_at or Not available>
+Call id: <result.call_id or Not available>
+
+[Transcript]
+<result.transcript or Not available.>
+```
+
+If the user requested extra final content, add it after `[Transcript]` using a
+short heading and only information present in the JSON output.
+
+## JSON handling
+
+- Treat command output as JSON.
+- If `ok` is false and `error.code` is `auth_required`, run or suggest
+  `auth login`, then retry after login completes.
+- Preserve `plan_id`, `confirm_token`, and `run_id` exactly as returned.
+- Show non-terminal `activity` progress clearly without exposing tokens.
+- Do not invent transcript text. If `result.transcript` is absent or empty,
+  write `Not available.` in the transcript section.

--- a/packages/skills-sh-skill/test/check-skill.test.js
+++ b/packages/skills-sh-skill/test/check-skill.test.js
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { checkSkillsShSkill } from "../scripts/check-skill.mjs";
+
+const PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const REPO_ROOT = path.resolve(PACKAGE_ROOT, "../..");
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeFile(filePath, source) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, source);
+}
+
+function makeTempRoot(name) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `${name}-`));
+}
+
+function createValidFixture(root, { packageVersion = "0.1.0", integrationVersion = packageVersion } = {}) {
+  const packageRoot = path.join(root, "packages", "skills-sh-skill");
+  const repoRoot = root;
+
+  writeJson(path.join(packageRoot, "package.json"), {
+    name: "@call-e/skills-sh-skill",
+    version: packageVersion,
+    private: true,
+    files: ["README.md", "skills"],
+    scripts: {
+      check: "node ./scripts/check-skill.mjs",
+      test: "node --test ./test/*.test.js",
+      "pack:dry-run": "npm pack --dry-run",
+    },
+  });
+
+  writeFile(
+    path.join(packageRoot, "skills", "calle", "SKILL.md"),
+    [
+      "---",
+      "name: calle",
+      "description: Test CALL-E skills.sh skill.",
+      "---",
+      "",
+      "# calle",
+      "",
+      "Run auth login --start-only --no-browser-open and ask the user to use the authorization instructions returned by the CLI.",
+      "Run auth login --no-browser-open to exchange a pending authorization.",
+      "Great, authorization is complete",
+      "Use assistant_hint.message after auth login and handle auth_required errors.",
+      "Use call plan, call run, and call status.",
+      "Phone call is in progress! Progress:",
+      "After call run, do not use `run_result` for the user-visible reply.",
+      "Use status_result.structuredContent.",
+      "Never paraphrase call results.",
+      "For non-terminal statuses, the entire reply must be exactly this shape.",
+      "Poll every 10 seconds.",
+      `Run with CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=${integrationVersion}.`,
+      "Use npx -y @call-e/cli@0.3.2 when no local CLI exists.",
+      "",
+    ].join("\n"),
+  );
+
+  writeFile(
+    path.join(packageRoot, "skills", "calle", "agents", "openai.yaml"),
+    [
+      "interface:",
+      '  display_name: "calle"',
+      '  short_description: "CALL-E phone calls from agent skills"',
+      '  default_prompt: "Use $calle to place or check a CALL-E phone call."',
+      "",
+    ].join("\n"),
+  );
+
+  writeFile(
+    path.join(packageRoot, "skills", "calle", "references", "commands.md"),
+    [
+      "# Commands",
+      "",
+      `env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=${integrationVersion} node packages/cli/bin/calle.js`,
+      `env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=${integrationVersion} npx -y @call-e/cli@0.3.2`,
+      "Run auth login --start-only --no-browser-open and ask the user to use the authorization instructions returned by the CLI.",
+      "Run auth login --no-browser-open to exchange a pending authorization.",
+      "Great, authorization is complete",
+      "Handle auth_required and assistant_hint.message.",
+      "Use call plan, call run, and call status.",
+      "Phone call is in progress! Progress:",
+      "Do not use run_result for the user-visible reply.",
+      "Use status_result.structuredContent.",
+      "Never paraphrase call results.",
+      "For non-terminal statuses, the entire reply must be exactly this shape.",
+      "Wait 10 seconds before polling again.",
+      "",
+    ].join("\n"),
+  );
+
+  writeFile(path.join(repoRoot, "README.md"), "packages/skills-sh-skill\ndocs/install/skills-sh-skill.md\n");
+  writeFile(path.join(repoRoot, "docs", "install", "skills-sh-skill.md"), "# Install\n");
+  writeFile(path.join(repoRoot, "docs", "agent-integration-layout.md"), "skills.sh\npackages/skills-sh-skill\n");
+
+  return { packageRoot, repoRoot };
+}
+
+test("current skills.sh skill metadata is valid", () => {
+  assert.deepEqual(checkSkillsShSkill({ packageRoot: PACKAGE_ROOT, repoRoot: REPO_ROOT }), []);
+});
+
+test("reports a missing calle skill", () => {
+  const { packageRoot, repoRoot } = createValidFixture(makeTempRoot("calle-skills-sh-skill-missing"));
+  fs.rmSync(path.join(packageRoot, "skills", "calle"), { recursive: true, force: true });
+
+  const failures = checkSkillsShSkill({ packageRoot, repoRoot });
+  assert.ok(failures.some((failure) => failure.includes("skills/calle")));
+});
+
+test("reports a non-standard skill name", () => {
+  const { packageRoot, repoRoot } = createValidFixture(makeTempRoot("calle-skills-sh-skill-bad-name"));
+  const skillFile = path.join(packageRoot, "skills", "calle", "SKILL.md");
+  const source = fs.readFileSync(skillFile, "utf8");
+  fs.writeFileSync(skillFile, source.replace("name: calle", "name: Phone Call - CALL-E"));
+
+  const failures = checkSkillsShSkill({ packageRoot, repoRoot });
+  assert.ok(failures.some((failure) => failure.includes('frontmatter name must be "calle"')));
+});
+
+test("reports stale integration attribution", () => {
+  const { packageRoot, repoRoot } = createValidFixture(makeTempRoot("calle-skills-sh-skill-stale-attribution"));
+  const referenceFile = path.join(packageRoot, "skills", "calle", "references", "commands.md");
+  const source = fs.readFileSync(referenceFile, "utf8");
+  fs.writeFileSync(referenceFile, source.replaceAll("CALLE_SOURCE=skills_sh", "CALLE_SOURCE=openclaw"));
+
+  const failures = checkSkillsShSkill({ packageRoot, repoRoot });
+  assert.ok(failures.some((failure) => failure.includes("CALLE_SOURCE=skills_sh")));
+});
+
+test("reports stale integration version", () => {
+  const { packageRoot, repoRoot } = createValidFixture(
+    makeTempRoot("calle-skills-sh-skill-stale-version"),
+    { packageVersion: "9.8.7", integrationVersion: "0.1.0" },
+  );
+
+  const failures = checkSkillsShSkill({ packageRoot, repoRoot });
+  assert.ok(failures.some((failure) => failure.includes("CALLE_INTEGRATION_VERSION=9.8.7")));
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,8 @@ importers:
 
   packages/openclaw-cli-skill: {}
 
+  packages/skills-sh-skill: {}
+
 packages:
 
   '@babel/runtime@7.29.2':

--- a/scripts/sync-install-doc-versions.mjs
+++ b/scripts/sync-install-doc-versions.mjs
@@ -13,6 +13,7 @@ const syncedInstallFiles = [
   "docs/install/cursor.md",
   "docs/install/cursor-plugin.md",
   "docs/install/openclaw-cli-skill.md",
+  "docs/install/skills-sh-skill.md",
   "docs/agent-integration-layout.md",
   "packages/codex-plugin/README.md",
   "packages/codex-plugin/plugin/README.md",
@@ -29,6 +30,9 @@ const syncedInstallFiles = [
   "packages/openclaw-cli-skill/README.md",
   "packages/openclaw-cli-skill/skills/phone-call-calle/SKILL.md",
   "packages/openclaw-cli-skill/skills/phone-call-calle/references/commands.md",
+  "packages/skills-sh-skill/README.md",
+  "packages/skills-sh-skill/skills/calle/SKILL.md",
+  "packages/skills-sh-skill/skills/calle/references/commands.md",
 ];
 
 const codexLatestInstallFiles = new Set([
@@ -56,6 +60,13 @@ const openclawCliSkillIntegrationFiles = new Set([
   "packages/openclaw-cli-skill/README.md",
   "packages/openclaw-cli-skill/skills/phone-call-calle/SKILL.md",
   "packages/openclaw-cli-skill/skills/phone-call-calle/references/commands.md",
+]);
+
+const skillsShSkillIntegrationFiles = new Set([
+  "docs/install/skills-sh-skill.md",
+  "packages/skills-sh-skill/README.md",
+  "packages/skills-sh-skill/skills/calle/SKILL.md",
+  "packages/skills-sh-skill/skills/calle/references/commands.md",
 ]);
 
 const claudeCliIntegrationFiles = new Set([
@@ -104,6 +115,14 @@ const openclawCliSkillIntegrationReplacements = [
   },
 ];
 
+const skillsShSkillIntegrationReplacements = [
+  {
+    label: "skills.sh skill integration attribution version",
+    pattern: /CALLE_INTEGRATION_VERSION=\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/g,
+    value: `CALLE_INTEGRATION_VERSION=${readPackageVersion("packages/skills-sh-skill")}`,
+  },
+];
+
 const claudeCliIntegrationReplacements = [
   {
     label: "Claude Code plugin CLI integration attribution version",
@@ -140,11 +159,13 @@ for (const relativePath of syncedInstallFiles) {
     ? codexIntegrationReplacements
     : openclawCliSkillIntegrationFiles.has(relativePath)
       ? openclawCliSkillIntegrationReplacements
-      : claudeCliIntegrationFiles.has(relativePath)
-        ? claudeCliIntegrationReplacements
-        : cursorCliIntegrationFiles.has(relativePath)
-          ? cursorCliIntegrationReplacements
-        : [];
+      : skillsShSkillIntegrationFiles.has(relativePath)
+        ? skillsShSkillIntegrationReplacements
+        : claudeCliIntegrationFiles.has(relativePath)
+          ? claudeCliIntegrationReplacements
+          : cursorCliIntegrationFiles.has(relativePath)
+            ? cursorCliIntegrationReplacements
+            : [];
 
   for (const replacement of integrationReplacements) {
     nextSource = nextSource.replace(replacement.pattern, replacement.value);


### PR DESCRIPTION
## Summary
- Add a portable skills.sh-compatible calle skill package.
- Document skills.sh install paths in README and install docs.
- Wire skills.sh docs into install version synchronization and package checks.
- Derive skill integration version checks from package.json to avoid release-version drift.

## Verification
- pnpm --filter @call-e/skills-sh-skill test
- pnpm --filter @call-e/skills-sh-skill check
- pnpm run check:versions
- pnpm check
- pnpm test
