### PR TITLE
fix(skills-sh): expose calle for public search

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Use the native release path when available:
 - OpenClaw: run `openclaw skills install phone-call-calle`.
 - Hermes Agent: open `https://clawhub.ai/call-e-dev/phone-call-calle`, choose Prompt, and paste the ClawHub install prompt into Hermes.
 - Codex: add the CALL-E plugin marketplace from `CALLE-AI/call-e-integrations` using the official Codex command in this README.
-- skills.sh compatible agents: install the `calle` skill from `packages/skills-sh-skill/skills/calle`.
+- skills.sh compatible agents: install the `calle` skill from `CALLE-AI/call-e-integrations`; the public discovery mirror lives at `skills/calle`.
 - CLI users: install `@call-e/cli`, then run `calle auth login`.
 - MCP-only clients: use Streamable HTTP with `https://seleven-mcp-sg.airudder.com/mcp/openagent_oauth`.
 
@@ -74,11 +74,12 @@ $calle
 Install the portable `calle` skill with the skills CLI:
 
 ```bash
-npx skills add https://github.com/CALLE-AI/call-e-integrations/tree/main/packages/skills-sh-skill/skills/calle -a codex
+npx skills add https://github.com/CALLE-AI/call-e-integrations --skill calle -a codex
 ```
 
 Use another supported `-a <agent>` value when installing for a different
-skills.sh compatible agent.
+skills.sh compatible agent. For direct source installs, use
+`https://github.com/CALLE-AI/call-e-integrations/tree/main/packages/skills-sh-skill/skills/calle`.
 
 ### Claude Code
 
@@ -202,7 +203,7 @@ Then complete the client OAuth flow and verify the available tools include `plan
 - OpenClaw user installs should use ClawHub: `openclaw skills install phone-call-calle`.
 - Hermes Agent user installs should use the ClawHub Prompt flow from the same skill page; this repository does not publish a separate Hermes plugin.
 - This repository keeps the OpenClaw skill source at `packages/openclaw-cli-skill/skills/phone-call-calle` for local development and validation.
-- skills.sh compatible installs should use the direct GitHub tree path for `packages/skills-sh-skill/skills/calle`.
+- skills.sh compatible installs should use the repository root with `--skill calle`; the root `skills/calle` mirror exists so skills.sh search and detail pages can index the same portable skill. The package source remains at `packages/skills-sh-skill/skills/calle`.
 
 Install guides: [CLI](./docs/install/cli.md) · [Codex](./docs/install/codex-plugin.md) · [skills.sh](./docs/install/skills-sh-skill.md) · [Claude Code](./docs/install/claude-plugin.md) · [Cursor MCP](./docs/install/cursor.md) · [Cursor plugin](./docs/install/cursor-plugin.md) · [OpenClaw source](./docs/install/openclaw-cli-skill.md)
 
@@ -285,6 +286,7 @@ packages/claude-plugin/plugin/                # Claude Code plugin source
 packages/cursor-plugin/plugin/                # Cursor plugin source
 packages/openclaw-cli-skill/skills/            # OpenClaw skill source
 packages/skills-sh-skill/skills/               # skills.sh compatible skill source
+skills/calle/                                  # skills.sh public discovery mirror
 packages/cli/                                  # Shared calle CLI
 packages/core/                                 # Shared runtime helpers
 examples/                                      # Runnable MCP demos, not an SDK
@@ -312,6 +314,7 @@ examples/                                      # Runnable MCP demos, not an SDK
 | OpenClaw skill | name | `Phone Call - CALL-E` |
 | skills.sh skill | name | `calle` |
 | skills.sh skill source | path | `packages/skills-sh-skill/skills/calle` |
+| skills.sh public discovery mirror | path | `skills/calle` |
 | skills.sh CLI attribution | env | `skills_sh/skills_sh_skill/<version>` |
 
 ## 🧪 Examples

--- a/docs/agent-integration-layout.md
+++ b/docs/agent-integration-layout.md
@@ -29,6 +29,7 @@ Current skills.sh layout:
 
 ```text
 packages/skills-sh-skill/skills/
+skills/calle/
 ```
 
 Current Claude Code layout:
@@ -47,7 +48,9 @@ packages/cursor-plugin/plugin/
 
 Use `packages/openclaw-cli-skill/skills/` for the OpenClaw CALL-E skill source.
 Use `packages/skills-sh-skill/skills/` for the skills.sh compatible CALL-E
-skill source.
+skill source. Keep `skills/calle/` as the repository-root mirror of that source
+so skills.sh public search and detail pages can index the portable `calle`
+skill from the default repository install path.
 Use `.agents/skills/` for repository-local Codex helper skills. Do not put
 productized client-specific skill packages there; keep them under their owning
 package.
@@ -89,6 +92,8 @@ For skills.sh:
 
 - The skills.sh package path must stay `packages/skills-sh-skill`.
 - The skills.sh skill directory must stay `packages/skills-sh-skill/skills/calle`.
+- The skills.sh public discovery mirror must stay `skills/calle` and match the
+  package skill directory.
 - The skills.sh skill frontmatter `name` must stay `calle`.
 - The skills.sh CLI integration attribution must stay
   `skills_sh/skills_sh_skill/<version>`.
@@ -220,15 +225,15 @@ submission; publication is a separate operational step.
 
 skills.sh install example:
 
-Use the direct GitHub tree path so `skills` installs only the portable `calle`
-skill and does not discover repository-local helper skills:
+Use the repository root with `--skill calle` so skills.sh installs the portable
+`calle` skill from the root public discovery mirror:
+
+```bash
+npx skills add https://github.com/CALLE-AI/call-e-integrations --skill calle -a codex
+```
+
+Or install the package source directly:
 
 ```bash
 npx skills add https://github.com/CALLE-AI/call-e-integrations/tree/main/packages/skills-sh-skill/skills/calle -a codex
-```
-
-Or install from the skills package directory and select `calle`:
-
-```bash
-npx skills add https://github.com/CALLE-AI/call-e-integrations/tree/main/packages/skills-sh-skill/skills --skill calle -a codex
 ```

--- a/docs/install/skills-sh-skill.md
+++ b/docs/install/skills-sh-skill.md
@@ -1,21 +1,22 @@
 # Install The CALL-E skills.sh Skill
 
 The skills.sh compatible integration path in this repository is the `calle`
-skill at `packages/skills-sh-skill/skills/calle`. It teaches any compatible
-agent to use CALL-E through the shared `calle` CLI.
+skill. The package source lives at `packages/skills-sh-skill/skills/calle`, and
+the repository root mirrors it at `skills/calle` so skills.sh can index the
+public skill page and search results.
 
 ## Install From GitHub
 
-Install the direct skill path:
+Install from the repository root and select the public `calle` skill:
+
+```bash
+npx skills add https://github.com/CALLE-AI/call-e-integrations --skill calle -a codex
+```
+
+Or install the direct package skill path:
 
 ```bash
 npx skills add https://github.com/CALLE-AI/call-e-integrations/tree/main/packages/skills-sh-skill/skills/calle -a codex
-```
-
-Or install from the package skills directory and select `calle`:
-
-```bash
-npx skills add https://github.com/CALLE-AI/call-e-integrations/tree/main/packages/skills-sh-skill/skills --skill calle -a codex
 ```
 
 Replace `codex` with another supported agent when needed.
@@ -42,7 +43,9 @@ pnpm --filter @call-e/skills-sh-skill check
 pnpm --filter @call-e/skills-sh-skill test
 pnpm --filter @call-e/skills-sh-skill pack:dry-run
 npx -y skills-ref validate ./packages/skills-sh-skill/skills/calle
+npx -y skills add ./skills/calle --list
 npx -y skills add ./packages/skills-sh-skill/skills/calle --list
+npx -y skills add https://github.com/CALLE-AI/call-e-integrations --skill calle --list
 ```
 
 ## More

--- a/packages/skills-sh-skill/README.md
+++ b/packages/skills-sh-skill/README.md
@@ -2,6 +2,8 @@
 
 skills.sh compatible CALL-E skill for making real outbound phone calls,
 running planned calls, and checking call status through the `calle` CLI.
+This package remains the source of truth; the repository root mirrors it at
+`skills/calle` for skills.sh public discovery and search indexing.
 
 For setup steps, see
 [docs/install/skills-sh-skill.md](../../docs/install/skills-sh-skill.md).
@@ -27,6 +29,7 @@ pnpm --filter @call-e/skills-sh-skill check
 pnpm --filter @call-e/skills-sh-skill test
 pnpm --filter @call-e/skills-sh-skill pack:dry-run
 npx -y skills-ref validate ./packages/skills-sh-skill/skills/calle
+npx -y skills add ./skills/calle --list
 npx -y skills add ./packages/skills-sh-skill/skills/calle --list
 ```
 

--- a/packages/skills-sh-skill/scripts/check-skill.mjs
+++ b/packages/skills-sh-skill/scripts/check-skill.mjs
@@ -62,6 +62,27 @@ function integrationVersionSnippet(packageJson) {
     : null;
 }
 
+function listRelativeFiles(rootDir) {
+  const files = [];
+
+  function walk(currentDir) {
+    for (const dirent of fs.readdirSync(currentDir, { withFileTypes: true })) {
+      const absolutePath = path.join(currentDir, dirent.name);
+      if (dirent.isDirectory()) {
+        walk(absolutePath);
+        continue;
+      }
+
+      if (dirent.isFile()) {
+        files.push(path.relative(rootDir, absolutePath).split(path.sep).join("/"));
+      }
+    }
+  }
+
+  walk(rootDir);
+  return files.sort();
+}
+
 function checkPackage({ packageRoot, failures }) {
   const packageJsonPath = path.join(packageRoot, "package.json");
   const packageJson = readJson(packageJsonPath, failures);
@@ -176,6 +197,36 @@ function checkSkill({ packageRoot, packageJson, failures }) {
   });
 }
 
+function checkPublicDiscoveryMirror({ packageRoot, repoRoot, failures }) {
+  const sourceDir = path.join(packageRoot, "skills", EXPECTED_SKILL_DIR);
+  const mirrorDir = path.join(repoRoot, "skills", EXPECTED_SKILL_DIR);
+
+  assert(fs.existsSync(mirrorDir), failures, `Missing skills.sh public discovery mirror: ${mirrorDir}`);
+
+  if (!fs.existsSync(sourceDir) || !fs.existsSync(mirrorDir)) {
+    return;
+  }
+
+  const sourceFiles = listRelativeFiles(sourceDir);
+  const mirrorFiles = listRelativeFiles(mirrorDir);
+  const sourceFileSet = new Set(sourceFiles);
+  const mirrorFileSet = new Set(mirrorFiles);
+  const allFiles = [...new Set([...sourceFiles, ...mirrorFiles])].sort();
+
+  for (const relativeFile of allFiles) {
+    assert(sourceFileSet.has(relativeFile), failures, `skills.sh public discovery mirror has unexpected file: ${path.join(mirrorDir, relativeFile)}`);
+    assert(mirrorFileSet.has(relativeFile), failures, `skills.sh public discovery mirror is missing file: ${path.join(mirrorDir, relativeFile)}`);
+
+    if (!sourceFileSet.has(relativeFile) || !mirrorFileSet.has(relativeFile)) {
+      continue;
+    }
+
+    const source = fs.readFileSync(path.join(sourceDir, relativeFile), "utf8");
+    const mirror = fs.readFileSync(path.join(mirrorDir, relativeFile), "utf8");
+    assert(source === mirror, failures, `skills.sh public discovery mirror is stale: ${path.join(mirrorDir, relativeFile)} must match ${path.join(sourceDir, relativeFile)}.`);
+  }
+}
+
 function checkRepoDocs({ repoRoot, failures }) {
   const readmePath = path.join(repoRoot, "README.md");
   const installDocPath = path.join(repoRoot, "docs", "install", "skills-sh-skill.md");
@@ -186,12 +237,14 @@ function checkRepoDocs({ repoRoot, failures }) {
   if (fs.existsSync(readmePath)) {
     const readme = fs.readFileSync(readmePath, "utf8");
     assert(readme.includes("packages/skills-sh-skill"), failures, "README.md must mention packages/skills-sh-skill.");
+    assert(readme.includes("skills/calle"), failures, "README.md must mention the skills.sh public discovery mirror at skills/calle.");
     assert(readme.includes("docs/install/skills-sh-skill.md"), failures, "README.md must link to the skills.sh install guide.");
   }
 
   if (fs.existsSync(layoutPath)) {
     const layout = fs.readFileSync(layoutPath, "utf8");
     assert(layout.includes("packages/skills-sh-skill"), failures, "docs/agent-integration-layout.md must mention packages/skills-sh-skill.");
+    assert(layout.includes("skills/calle"), failures, "docs/agent-integration-layout.md must mention the skills.sh public discovery mirror at skills/calle.");
     assert(layout.includes("skills.sh"), failures, "docs/agent-integration-layout.md must describe the skills.sh skill boundary.");
   }
 }
@@ -203,6 +256,7 @@ export function checkSkillsShSkill({
   const failures = [];
   const packageJson = checkPackage({ packageRoot, failures });
   checkSkill({ packageRoot, packageJson, failures });
+  checkPublicDiscoveryMirror({ packageRoot, repoRoot, failures });
   checkRepoDocs({ repoRoot, failures });
   return failures;
 }

--- a/packages/skills-sh-skill/test/check-skill.test.js
+++ b/packages/skills-sh-skill/test/check-skill.test.js
@@ -20,6 +20,14 @@ function writeFile(filePath, source) {
   fs.writeFileSync(filePath, source);
 }
 
+function mirrorSkillsShSkill({ packageRoot, repoRoot }) {
+  fs.cpSync(
+    path.join(packageRoot, "skills", "calle"),
+    path.join(repoRoot, "skills", "calle"),
+    { recursive: true },
+  );
+}
+
 function makeTempRoot(name) {
   return fs.mkdtempSync(path.join(os.tmpdir(), `${name}-`));
 }
@@ -100,9 +108,10 @@ function createValidFixture(root, { packageVersion = "0.1.0", integrationVersion
     ].join("\n"),
   );
 
-  writeFile(path.join(repoRoot, "README.md"), "packages/skills-sh-skill\ndocs/install/skills-sh-skill.md\n");
+  writeFile(path.join(repoRoot, "README.md"), "packages/skills-sh-skill\nskills/calle\ndocs/install/skills-sh-skill.md\n");
   writeFile(path.join(repoRoot, "docs", "install", "skills-sh-skill.md"), "# Install\n");
-  writeFile(path.join(repoRoot, "docs", "agent-integration-layout.md"), "skills.sh\npackages/skills-sh-skill\n");
+  writeFile(path.join(repoRoot, "docs", "agent-integration-layout.md"), "skills.sh\npackages/skills-sh-skill\nskills/calle\n");
+  mirrorSkillsShSkill({ packageRoot, repoRoot });
 
   return { packageRoot, repoRoot };
 }
@@ -147,4 +156,14 @@ test("reports stale integration version", () => {
 
   const failures = checkSkillsShSkill({ packageRoot, repoRoot });
   assert.ok(failures.some((failure) => failure.includes("CALLE_INTEGRATION_VERSION=9.8.7")));
+});
+
+test("reports a stale public discovery mirror", () => {
+  const { packageRoot, repoRoot } = createValidFixture(makeTempRoot("calle-skills-sh-skill-stale-mirror"));
+  const mirrorSkillFile = path.join(repoRoot, "skills", "calle", "SKILL.md");
+  const source = fs.readFileSync(mirrorSkillFile, "utf8");
+  fs.writeFileSync(mirrorSkillFile, source.replace("Test CALL-E skills.sh skill.", "Stale CALL-E skills.sh skill."));
+
+  const failures = checkSkillsShSkill({ packageRoot, repoRoot });
+  assert.ok(failures.some((failure) => failure.includes("public discovery mirror is stale")));
 });

--- a/scripts/sync-install-doc-versions.mjs
+++ b/scripts/sync-install-doc-versions.mjs
@@ -33,6 +33,8 @@ const syncedInstallFiles = [
   "packages/skills-sh-skill/README.md",
   "packages/skills-sh-skill/skills/calle/SKILL.md",
   "packages/skills-sh-skill/skills/calle/references/commands.md",
+  "skills/calle/SKILL.md",
+  "skills/calle/references/commands.md",
 ];
 
 const codexLatestInstallFiles = new Set([
@@ -67,6 +69,8 @@ const skillsShSkillIntegrationFiles = new Set([
   "packages/skills-sh-skill/README.md",
   "packages/skills-sh-skill/skills/calle/SKILL.md",
   "packages/skills-sh-skill/skills/calle/references/commands.md",
+  "skills/calle/SKILL.md",
+  "skills/calle/references/commands.md",
 ]);
 
 const claudeCliIntegrationFiles = new Set([

--- a/skills/calle/SKILL.md
+++ b/skills/calle/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: calle
+description: Use CALL-E from skills.sh compatible agents through the calle CLI. Use for CALL-E setup checks, authentication recovery, phone call planning, placing real outbound calls, planned call execution, call status polling, summaries, details, and transcripts.
+---
+
+# calle
+
+Use CALL-E from skills.sh compatible agents through the shared `calle` CLI.
+
+CALL-E can place real outbound phone calls. Always plan first, preserve returned
+credentials exactly, and only run a planned call when the user clearly intends
+to place that call.
+
+## Safety
+
+- Real calls may contact external people or businesses.
+- Do not place a real call unless the user clearly intends to do so.
+- Always run `call plan` before `call run`.
+- If the user asked to place a call, run it immediately after planning returns
+  a valid `plan_id` and `confirm_token`.
+- If the user asked only to verify setup or only to plan, do not run the call.
+- Do not guess phone numbers, country codes, language, region, `plan_id`,
+  `confirm_token`, or `run_id`.
+- Do not print, request, or expose access tokens.
+
+## CLI Selection
+
+All CLI commands run from this skill must include the CALL-E integration
+attribution environment:
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0
+```
+
+Use the first command form that works.
+
+Prefer the repository-local CLI when the current workspace contains it:
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 node packages/cli/bin/calle.js
+```
+
+If the repository-local CLI is unavailable, use the global command:
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle
+```
+
+If neither command works, use the pinned npm package through `npx`:
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 npx -y @call-e/cli@0.3.2
+```
+
+Only tell the user to install the CLI globally if `npx` is unavailable,
+network access is blocked, or the user explicitly wants a persistent global
+command.
+
+## Readiness Flow
+
+Use this flow whenever this skill is actively invoked for a CALL-E request. Run
+it before call planning, before tool listing, when setup is uncertain, when
+auth fails, or when the user asks to verify CALL-E setup:
+
+1. Check CLI availability with `--help`.
+2. Run `auth status`.
+3. If `auth status` reports `usable: false`, do not continue to call planning
+   or `mcp tools` yet. Run `auth login --start-only --no-browser-open` to
+   create or reuse a brokered login session and return CLI-provided
+   authorization instructions without opening a browser inside the current
+   agent turn.
+4. Show the CLI-provided `assistant_hint.message` when it is present. If it is
+   absent, tell the user that authentication is required, ask them to follow
+   the authorization instructions returned by the CLI, and stop the current
+   workflow until they confirm authorization is complete. Do not invent or
+   rewrite authorization URLs, and never ask for credentials, secrets, or
+   tokens.
+5. When the user confirms browser authorization is complete, run
+   `auth login --no-browser-open` to poll the existing pending login, exchange
+   the authorized session, and write the local token cache.
+6. If the successful `auth login --no-browser-open` JSON included
+   `assistant_hint.message`, show that post-auth success message in the next
+   user-facing reply. If the user already gave a call goal, continue the
+   original workflow after the message; otherwise ask for the phone number and
+   call goal, or offer a test call.
+7. After login completes, run `mcp tools`.
+8. Confirm that `plan_call`, `run_call`, and `get_call_run` are available.
+
+Setup verification must not place a real phone call. Use only help, auth, and
+tool-listing commands until the user asks for a call workflow.
+
+Post-authorization success template:
+
+```text
+Great, authorization is complete
+
+- If you already shared the call goal, I'll continue as planned.
+- If you haven't, that's okay. I can help you place a test call first, or start a real call directly.
+
+You can tell me:
+- Your phone number: Used only for this service. We will not disclose it to anyone else, including the callee.
+- What you want me to say: For example, "This is a test call from CALL-E. Wishing you a good day, and asking if there's anything you'd like to share."
+
+I'll keep you updated on the phone status, call content, and summary.
+```
+
+## Call Flow
+
+1. Use `call plan` first.
+2. Read the returned `plan_id` and `confirm_token`.
+3. If the user's request is to place a call, immediately use `call run` with
+   the exact `plan_id` and `confirm_token` returned by planning.
+4. Do not ask for a second confirmation between `call plan` and `call run`.
+5. Read the returned `run_id` and latest call status. In `call run` output, the
+   latest call state is in `status_result.structuredContent`. In `call status`
+   output, the latest call state is in `result.structuredContent`.
+6. After `call run`, do not use `run_result` for the user-visible reply except
+   to preserve the returned `run_id`. Treat `status_result.structuredContent`
+   as the latest `get_call_run` result and base the user-visible reply on that
+   object.
+7. After `call status`, treat `result.structuredContent` as the latest
+   `get_call_run` result and base the user-visible reply on that object.
+8. If the latest status is not terminal, immediately show a user-visible
+   progress update from the latest activity data before polling again. Use
+   `status_result.structuredContent.activity` after `call run`, or
+   `result.structuredContent.activity` after `call status`.
+9. Keep using `call status` with that exact `run_id` until the call reaches a
+   terminal status or the user asks you to stop. Poll every 10 seconds: after
+   each non-terminal response, show the latest activity progress, wait 10
+   seconds, then fetch `call status` again. Do not stay silent until a terminal
+   status.
+10. Use `call status` only with a known `run_id`.
+
+If any command returns `auth_required`, switch to the readiness flow, complete
+login, and then retry the original operation after login completes.
+
+Never paraphrase call results into free-form prose such as
+`The call succeeded. Result: ...`. Do not translate the headings, do not add
+extra commentary, and do not wrap the result in code fences.
+
+For non-terminal statuses, the entire reply must be exactly this shape:
+
+```text
+Phone call is in progress! Progress:
+- <HH:MM:SS message>
+```
+
+Use one bullet per `activity` item, preserving the order returned by the CLI.
+For each item, prefer the event `ts` formatted as `HH:MM:SS` plus `message`.
+If `ts` is missing, use the message by itself. If there is no activity, use
+`- <message>` when `message` exists, otherwise use `- Status: <status>` when a
+status exists, otherwise use `- Waiting for the next status update.` Do not
+include the final summary, details, or transcript until a terminal status is
+returned.
+
+Terminal statuses include `COMPLETED`, `FAILED`, `NO_ANSWER`, `DECLINED`,
+`CANCELED`, `CANCELLED`, `VOICEMAIL`, `BUSY`, and `EXPIRED`.
+
+When the call reaches a terminal status, reply with the final call result,
+including these sections in this order:
+
+```text
+[Status]
+<status>
+
+[Call Summary]
+<post_summary or summary or message>
+
+[Details]
+Callee Number: <primary callee or Not available>
+Duration: <duration or Not available>
+Time: <start/end time or Not available>
+Call id: <call_id or Not available>
+
+[Transcript]
+<transcript or Not available.>
+```
+
+If the user asked for extra final content, such as key takeaways or next steps,
+add it after `[Transcript]` under a short heading. Base all final sections only
+on the JSON returned by `call run` or `call status`; do not invent a transcript.
+
+Use `references/commands.md` for exact command examples, supported options, and
+JSON handling rules.
+
+## Community
+
+For installation help, rollout updates, and feedback:
+
+- Discord: https://discord.gg/6AbXUzUV8w

--- a/skills/calle/agents/openai.yaml
+++ b/skills/calle/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "calle"
+  short_description: "CALL-E phone calls from agent skills"
+  default_prompt: "Use $calle to place or check a CALL-E phone call."

--- a/skills/calle/references/commands.md
+++ b/skills/calle/references/commands.md
@@ -1,0 +1,231 @@
+# CALL-E CLI commands
+
+Use the first command form that is available in the current workspace.
+
+Repository-local base command:
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 node packages/cli/bin/calle.js
+```
+
+Global base command:
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle
+```
+
+npx fallback base command:
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 npx -y @call-e/cli@0.3.2
+```
+
+## Setup and readiness
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 node packages/cli/bin/calle.js --help
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 node packages/cli/bin/calle.js auth status
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 node packages/cli/bin/calle.js auth login --start-only --no-browser-open
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 node packages/cli/bin/calle.js auth login --no-browser-open
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 node packages/cli/bin/calle.js mcp tools
+```
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle --help
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle auth status
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle auth login --start-only --no-browser-open
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle auth login --no-browser-open
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle mcp tools
+```
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 npx -y @call-e/cli@0.3.2 --help
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 npx -y @call-e/cli@0.3.2 auth status
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 npx -y @call-e/cli@0.3.2 auth login --start-only --no-browser-open
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 npx -y @call-e/cli@0.3.2 auth login --no-browser-open
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 npx -y @call-e/cli@0.3.2 mcp tools
+```
+
+Rules:
+
+- Treat all command output as JSON except `--help`.
+- Do not print or ask for access tokens.
+- Whenever this skill is actively invoked, run `auth status` before call
+  planning or tool listing.
+- If `auth status` reports `usable: false`, do not call `mcp tools` or
+  `call plan` yet. Run `auth login --start-only --no-browser-open` to create
+  or reuse a brokered login session and return CLI-provided authorization
+  instructions without opening a browser inside the current agent turn.
+- Show the CLI-provided `assistant_hint.message` when it is present. If it is
+  absent, tell the user that authentication is required, ask them to follow the
+  authorization instructions returned by the CLI, and stop the current workflow
+  until they confirm authorization is complete.
+- Do not invent or rewrite authorization URLs, and never ask for credentials,
+  secrets, or tokens.
+- When the user confirms browser authorization is complete, run
+  `auth login --no-browser-open` to poll the existing pending login, exchange
+  the authorized session, and write the local token cache.
+- If successful `auth login --no-browser-open` output includes
+  `assistant_hint.message`, show it as the post-authorization success note.
+  Then continue the original call workflow if the user already gave enough
+  details.
+- If a command returns `auth_required`, switch back to this auth flow.
+- If `mcp tools` succeeds, confirm that `plan_call`, `run_call`, and
+  `get_call_run` are present.
+- Do not run `call run` during setup verification.
+- Do not use raw HTTP or direct remote MCP configuration in this skill.
+
+Post-authorization success template:
+
+```text
+Great, authorization is complete
+
+- If you already shared the call goal, I'll continue as planned.
+- If you haven't, that's okay. I can help you place a test call first, or start a real call directly.
+
+You can tell me:
+- Your phone number: Used only for this service. We will not disclose it to anyone else, including the callee.
+- What you want me to say: For example, "This is a test call from CALL-E. Wishing you a good day, and asking if there's anything you'd like to share."
+
+I'll keep you updated on the phone status, call content, and summary.
+```
+
+## Call planning
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 node packages/cli/bin/calle.js call plan --to-phone +15551234567 --goal "Confirm the appointment"
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle call plan --to-phone +15551234567 --goal "Confirm the appointment"
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 npx -y @call-e/cli@0.3.2 call plan --to-phone +15551234567 --goal "Confirm the appointment"
+```
+
+Supported `call plan` options:
+
+- `--to-phone <phone>` repeatable
+- `--goal <text>`
+- `--language <language>`
+- `--region <region>`
+
+Only provide options when the value is explicitly known. Do not infer missing
+phone numbers, country codes, language, or region.
+
+## Planned call execution
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 node packages/cli/bin/calle.js call run --plan-id <plan_id> --confirm-token <confirm_token>
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle call run --plan-id <plan_id> --confirm-token <confirm_token>
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 npx -y @call-e/cli@0.3.2 call run --plan-id <plan_id> --confirm-token <confirm_token>
+```
+
+Supported `call run` options:
+
+- `--plan-id <id>`
+- `--confirm-token <token>`
+
+Run this command immediately after planning returns a valid `plan_id` and
+`confirm_token`, when the user's request is to place a call. Preserve `plan_id`
+and `confirm_token` exactly as returned by planning.
+
+`call run` calls `run_call`, then fetches `get_call_run` once. Do not use
+`run_result` for the user-visible reply except to preserve the returned
+`run_id`. Treat `status_result.structuredContent` as the latest
+`get_call_run` result. If that status is not terminal, show a user-visible
+progress update from `status_result.structuredContent.activity` immediately,
+then continue with `call status --run-id <run_id>` every 10 seconds until a
+terminal status is returned or the user asks you to stop.
+
+## Call status
+
+```bash
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 node packages/cli/bin/calle.js call status --run-id <run_id>
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle call status --run-id <run_id>
+env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 npx -y @call-e/cli@0.3.2 call status --run-id <run_id>
+```
+
+Supported `call status` options:
+
+- `--run-id <id>`
+- `--cursor <cursor>`
+- `--limit <number>`
+
+Use status commands only with a known `run_id`.
+
+Terminal statuses:
+
+- `COMPLETED`
+- `FAILED`
+- `NO_ANSWER`
+- `DECLINED`
+- `CANCELED`
+- `CANCELLED`
+- `VOICEMAIL`
+- `BUSY`
+- `EXPIRED`
+
+Read call data from `status_result.structuredContent` in `call run` output, or
+from `result.structuredContent` in `call status` output.
+
+Never paraphrase call results into free-form prose such as
+`The call succeeded. Result: ...`. Do not translate the headings, do not add
+extra commentary, and do not wrap the result in code fences.
+
+For `call run`, base the user-visible reply on
+`status_result.structuredContent`. For `call status`, base the user-visible
+reply on `result.structuredContent`.
+
+For non-terminal statuses, the entire reply must be exactly this shape:
+
+```text
+Phone call is in progress! Progress:
+- <HH:MM:SS message>
+```
+
+Use one bullet per `activity` item, preserving the order returned by the CLI.
+For `call run`, read activity from `status_result.structuredContent.activity`.
+For `call status`, read activity from `result.structuredContent.activity`.
+For each activity item, prefer the event `ts` formatted as `HH:MM:SS` plus
+`message`. If `ts` is missing, use the message by itself. If there is no
+activity, use `- <message>` when `message` exists, otherwise use
+`- Status: <status>` when a status exists, otherwise use
+`- Waiting for the next status update.` Do not wait silently for the terminal
+result.
+
+Polling cadence:
+
+1. Show the latest non-terminal progress.
+2. Wait 10 seconds.
+3. Run `call status --run-id <run_id>`.
+4. If the status is still non-terminal, show the new activity and repeat.
+5. Stop polling when a terminal status is returned, the user asks you to stop,
+   or command execution is interrupted.
+
+For terminal statuses, include the final transcript in the user-visible reply:
+
+```text
+[Status]
+<status>
+
+[Call Summary]
+<result.post_summary or result.summary or message>
+
+[Details]
+Callee Number: <result.extracted.to_phones[0] or result.extracted.calling.callee or Not available>
+Duration: <result.extracted.calling.duration_seconds or Not available>
+Time: <result.extracted.calling.started_at and ended_at or Not available>
+Call id: <result.call_id or Not available>
+
+[Transcript]
+<result.transcript or Not available.>
+```
+
+If the user requested extra final content, add it after `[Transcript]` using a
+short heading and only information present in the JSON output.
+
+## JSON handling
+
+- Treat command output as JSON.
+- If `ok` is false and `error.code` is `auth_required`, run or suggest
+  `auth login`, then retry after login completes.
+- Preserve `plan_id`, `confirm_token`, and `run_id` exactly as returned.
+- Show non-terminal `activity` progress clearly without exposing tokens.
+- Do not invent transcript text. If `result.transcript` is absent or empty,
+  write `Not available.` in the transcript section.


### PR DESCRIPTION
## Summary
- add root `skills/calle` public discovery mirror for the skills.sh portable CALL-E skill
- validate the mirror stays in sync with `packages/skills-sh-skill/skills/calle`
- update skills.sh install docs to use the root repository path with `--skill calle`

## Validation
- `pnpm --filter @call-e/skills-sh-skill check`
- `pnpm --filter @call-e/skills-sh-skill test`
- `pnpm run check:versions`
- `pnpm check`
- `pnpm test`
- `npx -y skills-ref validate ./skills/calle`
- `npx -y skills@latest add . --skill calle --list`
- `npx -y skills@latest add ./skills/calle --list`