### PR TITLE
fix(release): unblock package publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   pull-requests: write
 
 jobs:
@@ -34,6 +35,9 @@ jobs:
           node-version: 22
           cache: pnpm
           registry-url: https://registry.npmjs.org/
+
+      - name: Set up npm trusted publishing
+        run: npm install --global npm@11
 
       - name: Initialize Codex latest ref
         run: |
@@ -94,28 +98,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Verify npm auth and scope access
-        run: |
-          tmpdir=$(mktemp -d)
-          trap 'rm -rf "$tmpdir"' EXIT
-
-          cat > "$tmpdir/.npmrc" <<'EOF'
-          //registry.npmjs.org/:_authToken=${NPM_TOKEN}
-          EOF
-
-          scope="call-e"
-          npm_user=$(NPM_TOKEN="$NPM_TOKEN" npm whoami \
-            --userconfig="$tmpdir/.npmrc" \
-            --registry=https://registry.npmjs.org/)
-
-          echo "Authenticated npm user: $npm_user"
-          npm org ls "$scope" "$npm_user" \
-            --userconfig="$tmpdir/.npmrc" \
-            --registry=https://registry.npmjs.org/
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Create release PR or publish
         id: changesets
         uses: changesets/action@v1
@@ -126,8 +108,6 @@ jobs:
           title: "chore: release packages"
         env:
           GITHUB_TOKEN: ${{ env.RELEASE_GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Update Codex latest ref
         if: steps.changesets.outputs.published == 'true'

--- a/packages/cursor-plugin/scripts/check-plugin.mjs
+++ b/packages/cursor-plugin/scripts/check-plugin.mjs
@@ -92,7 +92,7 @@ function checkPackage({ packageRoot, failures }) {
   }
 
   assert(packageJson.name === EXPECTED_PACKAGE_NAME, failures, "package.json name must be @call-e/cursor-plugin.");
-  assert(packageJson.version === "0.1.0", failures, "package.json version must start at 0.1.0.");
+  assert(typeof packageJson.version === "string" && packageJson.version.length > 0, failures, "package.json must include a version.");
   assert(packageJson.type === "module", failures, "package.json type must be module.");
   assert(packageJson.license === "MIT", failures, "package.json license must be MIT.");
   assert(packageJson.private !== true, failures, "package.json must keep the Cursor plugin package publishable.");

--- a/packages/cursor-plugin/test/cursor-plugin.test.js
+++ b/packages/cursor-plugin/test/cursor-plugin.test.js
@@ -11,15 +11,6 @@ const PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 
 const REPO_ROOT = path.resolve(PACKAGE_ROOT, "../..");
 const VERSION = "0.1.0";
 const REMOTE_MCP_URL = "https://seleven-mcp-sg.airudder.com/mcp/openagent_oauth";
-const VALID_CLI_GUIDANCE =
-  "CALLE_SOURCE=cursor CALLE_INTEGRATION=cursor_plugin CALLE_INTEGRATION_VERSION=0.1.0\n\n" +
-  "node packages/cli/bin/calle.js\n\n" +
-  "npx -y @call-e/cli\n\n" +
-  "auth status\n\n" +
-  "mcp tools\n\n" +
-  "call plan\n\n" +
-  "call run\n\n" +
-  "call status\n\n";
 const VALID_CALL_GUIDANCE =
   "Prefer the Cursor MCP tools when available.\n\n" +
   "Use plan_call, run_call, and get_call_run.\n\n" +
@@ -30,15 +21,29 @@ const VALID_CALL_GUIDANCE =
   "Do not expose OAuth tokens, bearer tokens, authorization codes, callback URLs, refresh tokens, or access tokens.\n\n" +
   "Do not configure CALL-E run_call for auto-run.\n\n" +
   "wait 60 seconds before the first `get_call_run`.\n\n";
-const VALID_SKILL = `---
+function validCliGuidance(version = VERSION) {
+  return (
+    "CALLE_SOURCE=cursor CALLE_INTEGRATION=cursor_plugin CALLE_INTEGRATION_VERSION=" + version + "\n\n" +
+    "node packages/cli/bin/calle.js\n\n" +
+    "npx -y @call-e/cli\n\n" +
+    "auth status\n\n" +
+    "mcp tools\n\n" +
+    "call plan\n\n" +
+    "call run\n\n" +
+    "call status\n\n"
+  );
+}
+function validSkill(version = VERSION) {
+  return `---
 name: calle
 description: Use CALL-E from Cursor for setup checks, authentication recovery, phone call planning, planned call execution, and call status checks.
 ---
 
 # CALL-E For Cursor
 
-${VALID_CALL_GUIDANCE}${VALID_CLI_GUIDANCE}
+${VALID_CALL_GUIDANCE}${validCliGuidance(version)}
 `;
+}
 const VALID_RULE = `---
 description: "CALL-E real phone call safety rules."
 alwaysApply: true
@@ -68,13 +73,13 @@ function makeTempRoot(name) {
   return fs.mkdtempSync(path.join(os.tmpdir(), `${name}-`));
 }
 
-function createValidFixture(root) {
+function createValidFixture(root, { version = VERSION } = {}) {
   const packageRoot = path.join(root, "packages", "cursor-plugin");
   const repoRoot = root;
 
   writeJson(path.join(packageRoot, "package.json"), {
     name: "@call-e/cursor-plugin",
-    version: VERSION,
+    version,
     type: "module",
     license: "MIT",
     files: ["README.md", "plugin"],
@@ -91,7 +96,7 @@ function createValidFixture(root) {
   writeJson(path.join(packageRoot, "plugin", ".cursor-plugin", "plugin.json"), {
     name: "calle",
     displayName: "CALL-E",
-    version: VERSION,
+    version,
     description: "Use CALL-E from Cursor through MCP, the calle CLI, and safety-aware agent skills.",
     author: {
       name: "CALLE AI",
@@ -112,8 +117,8 @@ function createValidFixture(root) {
     },
   });
 
-  writeFile(path.join(packageRoot, "plugin", "skills", "calle", "SKILL.md"), VALID_SKILL);
-  writeFile(path.join(packageRoot, "plugin", "skills", "calle", "references", "commands.md"), VALID_SKILL);
+  writeFile(path.join(packageRoot, "plugin", "skills", "calle", "SKILL.md"), validSkill(version));
+  writeFile(path.join(packageRoot, "plugin", "skills", "calle", "references", "commands.md"), validSkill(version));
   writeFile(path.join(packageRoot, "plugin", "rules", "call-e-safety.mdc"), VALID_RULE);
 
   const doc = `${REMOTE_MCP_URL}\nplan_call\nrun_call\nget_call_run\nreal outbound\nauto-run\n`;
@@ -144,6 +149,14 @@ function createValidFixture(root) {
 
 test("current Cursor plugin metadata is valid", () => {
   assert.deepEqual(checkCursorPlugin({ packageRoot: PACKAGE_ROOT, repoRoot: REPO_ROOT }), []);
+});
+
+test("accepts release-bumped package versions", () => {
+  const { packageRoot, repoRoot } = createValidFixture(makeTempRoot("calle-cursor-plugin-release-version"), {
+    version: "0.1.1",
+  });
+
+  assert.deepEqual(checkCursorPlugin({ packageRoot, repoRoot }), []);
 });
 
 test("reports a missing plugin manifest", () => {
@@ -187,7 +200,7 @@ test("reports missing skill safety guidance", () => {
   const { packageRoot, repoRoot } = createValidFixture(makeTempRoot("calle-cursor-plugin-missing-skill-guidance"));
   writeFile(
     path.join(packageRoot, "plugin", "skills", "calle", "SKILL.md"),
-    `---\nname: calle\ndescription: Use CALL-E from Cursor for setup checks, authentication recovery, phone call planning, planned call execution, and call status checks.\n---\n\n# Skill\n\n${VALID_CLI_GUIDANCE}`,
+    `---\nname: calle\ndescription: Use CALL-E from Cursor for setup checks, authentication recovery, phone call planning, planned call execution, and call status checks.\n---\n\n# Skill\n\n${validCliGuidance()}`,
   );
 
   const failures = checkCursorPlugin({ packageRoot, repoRoot });


### PR DESCRIPTION
## Summary
- stop hard-coding the Cursor plugin package version in metadata checks
- add a regression fixture for release-bumped Cursor plugin versions
- prepare the release workflow for npm Trusted Publishing via GitHub OIDC and npm 11

## Verification
- pnpm --filter @call-e/cursor-plugin test
- pnpm --filter @call-e/cursor-plugin check
- pnpm test
- pnpm check
- git diff --check

## Manual step before merging
Configure npm Trusted Publisher for each publishable package to trust this repo and workflow:
- organization/user: CALLE-AI
- repository: call-e-integrations
- workflow filename: release.yml
- packages: @call-e/claude-plugin, @call-e/codex-plugin, @call-e/core, @call-e/cursor-plugin, @call-e/cli

The release workflow will otherwise fail with npm authentication because the old token path requires OTP.