### PR TITLE
fix(release): use node 24 for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,12 +32,9 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org/
-
-      - name: Set up npm trusted publishing
-        run: npm install --global npm@11
 
       - name: Initialize Codex latest ref
         run: |


### PR DESCRIPTION
## Summary
- run the release job on Node 24 so npm Trusted Publishing uses a bundled npm 11 CLI
- remove the fragile global npm self-upgrade step that failed before publish

## Verification
- git diff --check
- pnpm run check:branch-name

## Context
The previous release run failed before publishing while trying to run npm install --global npm@11. Node 24 provides a compatible npm 11 directly for OIDC trusted publishing.