### PR TITLE
fix: cursor-plugin @latest tag, http retry, and login_url scheme validation

### DIFF
--- a/.changeset/fix-http-retry-and-login-url-validation.md
+++ b/.changeset/fix-http-retry-and-login-url-validation.md
@@ -1,0 +1,5 @@
+---
+"@call-e/core": patch
+---
+
+Add exponential backoff retry for transient HTTP errors (429, 5xx) and network failures in `requestJson`. Validate that `login_url` returned by the broker server uses the `https:` scheme before opening it in a browser (loopback addresses are exempt to support local development).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,34 @@ jobs:
           git tag "$latest_ref" "$release_commit"
           git push origin "refs/tags/${latest_ref}"
 
+      - name: Initialize Cursor latest ref
+        run: |
+          latest_ref="@call-e/cursor-plugin@latest"
+
+          if git ls-remote --exit-code --tags origin "$latest_ref" >/dev/null 2>&1; then
+            echo "${latest_ref} already exists."
+            exit 0
+          fi
+
+          cursor_version=$(node --input-type=module <<'EOF'
+          import fs from "node:fs";
+
+          const packageJson = JSON.parse(fs.readFileSync("packages/cursor-plugin/package.json", "utf8"));
+          console.log(packageJson.version);
+          EOF
+          )
+          release_ref="@call-e/cursor-plugin@${cursor_version}"
+
+          if ! release_commit=$(git rev-parse --verify --quiet "${release_ref}^{}"); then
+            echo "No local ${release_ref} tag found; leaving ${latest_ref} uninitialized."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$latest_ref" "$release_commit"
+          git push origin "refs/tags/${latest_ref}"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -155,6 +183,37 @@ jobs:
           }
 
           console.error(`Updating @call-e/claude-plugin@latest for @call-e/claude-plugin@${claudePlugin.version}.`);
+          console.log("true");
+          EOF
+          )
+
+          if [ "$should_update" != "true" ]; then
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -f "$latest_ref" "$GITHUB_SHA"
+          git push origin "refs/tags/${latest_ref}" --force
+
+      - name: Update Cursor latest ref
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: |
+          latest_ref="@call-e/cursor-plugin@latest"
+
+          should_update=$(node --input-type=module <<'EOF'
+          const packages = JSON.parse(process.env.PUBLISHED_PACKAGES || "[]");
+          const cursorPlugin = packages.find((pkg) => pkg.name === "@call-e/cursor-plugin");
+
+          if (!cursorPlugin) {
+            console.error("No @call-e/cursor-plugin package was published; leaving @call-e/cursor-plugin@latest unchanged.");
+            console.log("false");
+            process.exit(0);
+          }
+
+          console.error(`Updating @call-e/cursor-plugin@latest for @call-e/cursor-plugin@${cursorPlugin.version}.`);
           console.log("true");
           EOF
           )

--- a/packages/core/lib/broker-client.js
+++ b/packages/core/lib/broker-client.js
@@ -50,10 +50,22 @@ export async function exchangeBrokerSession(config, pending, { fetchImpl = globa
 }
 
 export function normalizePendingSession(sessionPayload) {
+  const loginUrl = String(sessionPayload.login_url);
+  let parsedLoginUrl;
+  try {
+    parsedLoginUrl = new URL(loginUrl);
+  } catch {
+    throw new Error("Broker session returned an invalid login_url");
+  }
+  const isLoopback = parsedLoginUrl.hostname === "localhost" || parsedLoginUrl.hostname === "127.0.0.1" || parsedLoginUrl.hostname === "::1";
+  if (parsedLoginUrl.protocol !== "https:" && !isLoopback) {
+    throw new Error(`Broker session login_url must use https:, got '${parsedLoginUrl.protocol}'`);
+  }
+
   return {
     session_id: String(sessionPayload.session_id),
     session_secret: String(sessionPayload.session_secret),
-    login_url: String(sessionPayload.login_url),
+    login_url: loginUrl,
     status: String(sessionPayload.status || "PENDING").toUpperCase(),
     created_at: new Date().toISOString(),
     expires_at: sessionPayload.expires_at ? String(sessionPayload.expires_at) : null,

--- a/packages/core/lib/http.js
+++ b/packages/core/lib/http.js
@@ -8,51 +8,79 @@ export class HttpStatusError extends Error {
   }
 }
 
+const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
+const MAX_RETRY_ATTEMPTS = 2;
+const RETRY_BASE_DELAY_MS = 500;
+
+async function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export async function requestJson(method, url, { headers = {}, json = undefined, timeoutSeconds = 15, fetchImpl = globalThis.fetch } = {}) {
   if (typeof fetchImpl !== "function") {
     throw new Error("global fetch is not available in this Node.js runtime");
   }
 
-  const controller = new AbortController();
-  const timeoutMs = Math.max(Math.ceil(Number(timeoutSeconds || 15) * 1000), 1000);
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  if (typeof timeout.unref === "function") {
-    timeout.unref();
-  }
+  let attempt = 0;
+  while (true) {
+    const controller = new AbortController();
+    const timeoutMs = Math.max(Math.ceil(Number(timeoutSeconds || 15) * 1000), 1000);
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    if (typeof timeout.unref === "function") {
+      timeout.unref();
+    }
 
-  try {
-    const response = await fetchImpl(url, {
-      method,
-      headers: {
-        Accept: "application/json",
-        ...(json !== undefined ? { "Content-Type": "application/json" } : {}),
-        ...headers,
-      },
-      body: json !== undefined ? JSON.stringify(json) : undefined,
-      signal: controller.signal,
-    });
-    const text = await response.text();
-    if (!response.ok) {
-      throw new HttpStatusError(`Client error '${response.status} ${response.statusText}' for url '${url}'`, {
-        statusCode: response.status,
-        responseText: text,
-        headers: Object.fromEntries(response.headers.entries()),
+    try {
+      const response = await fetchImpl(url, {
+        method,
+        headers: {
+          Accept: "application/json",
+          ...(json !== undefined ? { "Content-Type": "application/json" } : {}),
+          ...headers,
+        },
+        body: json !== undefined ? JSON.stringify(json) : undefined,
+        signal: controller.signal,
       });
+      const text = await response.text();
+      if (!response.ok) {
+        const error = new HttpStatusError(`Client error '${response.status} ${response.statusText}' for url '${url}'`, {
+          statusCode: response.status,
+          responseText: text,
+          headers: Object.fromEntries(response.headers.entries()),
+        });
+        if (attempt < MAX_RETRY_ATTEMPTS && RETRYABLE_STATUS_CODES.has(response.status)) {
+          attempt++;
+          const delayMs = RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1);
+          await sleep(delayMs);
+          continue;
+        }
+        throw error;
+      }
+      if (!text.trim()) {
+        return {};
+      }
+      const parsed = JSON.parse(text);
+      if (!parsed || typeof parsed !== "object") {
+        throw new Error(`Expected JSON object response for ${method} ${url}`);
+      }
+      return parsed;
+    } catch (error) {
+      if (error?.name === "AbortError") {
+        throw new Error(`Request timed out for ${method} ${url}`);
+      }
+      if (error instanceof HttpStatusError) {
+        throw error;
+      }
+      // Retry on network-level errors (ECONNRESET, ECONNREFUSED, etc.)
+      if (attempt < MAX_RETRY_ATTEMPTS) {
+        attempt++;
+        const delayMs = RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1);
+        await sleep(delayMs);
+        continue;
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
     }
-    if (!text.trim()) {
-      return {};
-    }
-    const parsed = JSON.parse(text);
-    if (!parsed || typeof parsed !== "object") {
-      throw new Error(`Expected JSON object response for ${method} ${url}`);
-    }
-    return parsed;
-  } catch (error) {
-    if (error?.name === "AbortError") {
-      throw new Error(`Request timed out for ${method} ${url}`);
-    }
-    throw error;
-  } finally {
-    clearTimeout(timeout);
   }
 }


### PR DESCRIPTION
## Summary

This PR brings three security and reliability fixes from [ashish993/call-e-integrations](https://github.com/ashish993/call-e-integrations) to improve the stability and security posture of the project.

### Changes

**1. Cursor plugin `@latest` tag initialization (release workflow)**
- Added `Initialize Cursor latest ref` and `Update Cursor latest ref` steps to the release workflow, matching the existing Codex and Claude plugin steps.
- The `cursor-plugin @latest` tag was never initialized or updated on publish — this fixes that gap.

**2. Exponential backoff HTTP retry (`packages/core/lib/http.js`)**
- Added retry logic in `requestJson` for transient HTTP errors (429, 500, 502, 503, 504) and network-level failures.
- Retries up to 2 times with 500ms / 1000ms delays before re-throwing.
- Improves resilience against flaky upstream MCP server responses.

**3. `login_url` scheme validation (`packages/core/lib/broker-client.js`)**
- Validates that the broker server's `login_url` uses `https:` before passing it to `openBrowser` / `spawn`.
- Loopback addresses (`localhost`, `127.0.0.1`, `::1`) are exempt to preserve local development and test compatibility.
- Mitigates open-redirect / scheme-injection risk from a malicious or misconfigured broker response.

### Testing
- Existing test suite passes (`pnpm test`).
- A changeset is included for the `@call-e/core` patch release.