### PR TITLE
docs: add supported regions and languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ curl "$CALLE_BASE_URL/v1/calls" \
 
 ---
 
-### Supported Regions and Languages
+## 🌍 Supported Regions and Languages
 
 CALL-E calling supports the following recipient region codes and spoken
 languages. Use these region codes with the SDK and API recipient settings.
@@ -223,8 +223,6 @@ languages. Use these region codes with the SDK and API recipient settings.
 | ID | English |
 | PH | English |
 | KE | English |
-
----
 
 ## 🧯 Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,34 @@ curl "$CALLE_BASE_URL/v1/calls" \
 
 ---
 
+### Supported Regions and Languages
+
+CALL-E calling supports the following recipient region codes and spoken
+languages. Use these region codes with the SDK and API recipient settings.
+
+| Recipient region code | Language(s) |
+| --- | --- |
+| US | English |
+| CN | English |
+| SG | English |
+| MY | English |
+| IN | English, Hindi |
+| AE | English, Arabic |
+| AU | English |
+| CA | English |
+| GB | English |
+| VN | Vietnamese |
+| DE | English, German |
+| JP | Japanese |
+| FR | French |
+| MX | Spanish |
+| BR | Portuguese |
+| ID | English |
+| PH | English |
+| KE | English |
+
+---
+
 ## 🧯 Troubleshooting
 
 If installation, authentication, or MCP tool verification fails, start with the


### PR DESCRIPTION
## Summary
- Add the officially supported recipient region and language matrix to the root README.
- Promote the matrix to a top-level README section with an emoji, consistent with the existing README structure.

## Checks
- git diff --check -- README.md
- node ./scripts/check-manifest-versions.mjs

Note: node ./scripts/sync-install-doc-versions.mjs --check still reports the existing Claude Code plugin install text mismatch, unrelated to this README addition.