### PR TITLE
fix(core): publish types and SDK contract guidance

### DIFF
--- a/.changeset/calm-phones-type.md
+++ b/.changeset/calm-phones-type.md
@@ -1,0 +1,6 @@
+---
+"@call-e/core": patch
+---
+
+Add TypeScript declarations and document the outbound tool, authentication
+preflight, and broker polling contracts.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -21,6 +21,63 @@ Public subpaths:
 - `@call-e/core/broker-client`
 - `@call-e/core/mcp-client`
 
+TypeScript declarations are included for the root export and every public
+subpath.
+
+## Authentication Preflight
+
+Check the cached token before starting an MCP request when the integration
+needs to return its own typed authentication state:
+
+```js
+import { currentTokenDocument } from "@call-e/core/mcp-client";
+
+if (!currentTokenDocument(config)) {
+  return { ok: false, code: "not_authenticated" };
+}
+```
+
+`currentTokenDocument` applies the configured minimum token TTL and returns
+`null` when the cache is missing, malformed, or too close to expiry.
+`tokenIsUsable` is also available from `@call-e/core` and
+`@call-e/core/cache` for callers that already hold a token document.
+
+## Broker Login Lifetime
+
+Broker session timing is server-directed:
+
+- Treat the returned `expires_at` as authoritative. Do not assume a fixed
+  session lifetime.
+- `loginWithBroker` follows `poll_after_ms`, clamped to 500-10,000 ms.
+- `pollTimeoutSeconds` limits how long the client waits; it does not extend the
+  login link lifetime. The fallback is 300 seconds.
+
+Operator-facing integrations can use `ensurePendingLogin` when they need to
+show the login URL and its remaining lifetime without blocking on the full
+login flow.
+
+## Outbound Call Contract
+
+CALL-E's outbound tools follow this order:
+
+```text
+plan_call -> run_call -> get_call_run
+```
+
+`plan_call` prepares a call without placing it. Only call `run_call` after the
+plan reports `ready_to_run=true`, using the exact `plan_id` and
+`confirm_token` returned by that plan. `get_call_run` reads progress and
+results using the `run_id` returned by `run_call`.
+
+`run_call` can place a real outbound phone call. Keep it behind explicit user
+approval and never use it as a connectivity test or auto-run tool.
+
+See the
+[OpenAgent OAuth MCP guide](https://github.com/CALLE-AI/call-e-integrations/blob/main/docs/mcp/openagent-oauth.md#tool-flow)
+for the tool inputs, result handoffs, polling guidance, and complete safety
+contract. At runtime, `listMcpTools` remains authoritative for the server's
+current MCP schemas.
+
 ## Development
 
 ```bash

--- a/packages/core/lib/broker-client.d.ts
+++ b/packages/core/lib/broker-client.d.ts
@@ -1,0 +1,98 @@
+import type { JsonObject, PendingLoginDocument, TokenDocument } from "./cache.js";
+
+export interface BrokerRequestConfig {
+  brokerBaseUrl: string;
+  timeoutSeconds: number;
+  integrationHeader?: string;
+}
+
+export interface CreateBrokerSessionConfig extends BrokerRequestConfig {
+  serverUrl: string;
+  authBaseUrl: string;
+  channel: string;
+  scope: string;
+  clientName: string;
+}
+
+export interface BrokerLoginConfig extends CreateBrokerSessionConfig {
+  cacheRoot: string;
+  minTtlSeconds?: number;
+  pollTimeoutSeconds?: number;
+}
+
+export interface BrokerSessionPayload extends JsonObject {
+  session_id: string;
+  session_secret: string;
+  login_url: string;
+  status?: string;
+  expires_at?: string | null;
+  poll_after_ms?: number | null;
+}
+
+export interface BrokerStatusPayload extends JsonObject {
+  session_id?: string;
+  session_secret?: string;
+  login_url?: string;
+  auth_url?: string;
+  verification_url?: string;
+  status?: string;
+  expires_at?: string | null;
+  error_message?: string | null;
+  poll_after_ms?: number | null;
+}
+
+export interface BrokerRequestOptions {
+  fetchImpl?: typeof globalThis.fetch;
+}
+
+export interface EnsurePendingLoginOptions extends BrokerRequestOptions {
+  forceLogin?: boolean;
+}
+
+export interface LoginWithBrokerOptions extends EnsurePendingLoginOptions {
+  openBrowser?: (loginUrl: string) => void | Promise<void>;
+  sleepImpl?: (milliseconds: number) => void | Promise<void>;
+  noBrowserOpen?: boolean;
+  stderr?: (message: string) => void;
+}
+
+export interface PendingLoginResult {
+  pending: PendingLoginDocument;
+  created: boolean;
+}
+
+export interface BrokerLoginResult {
+  status: "cached" | "logged_in";
+  cachePath: string;
+  pendingPath: string;
+  tokenDocument: TokenDocument;
+}
+
+export function createBrokerSession(
+  config: CreateBrokerSessionConfig,
+  options?: BrokerRequestOptions,
+): Promise<BrokerSessionPayload>;
+
+export function getBrokerSessionStatus(
+  config: BrokerRequestConfig,
+  pending: PendingLoginDocument,
+  options?: BrokerRequestOptions,
+): Promise<BrokerStatusPayload>;
+
+export function exchangeBrokerSession(
+  config: BrokerRequestConfig,
+  pending: PendingLoginDocument,
+  options?: BrokerRequestOptions,
+): Promise<TokenDocument>;
+
+export function normalizePendingSession(sessionPayload: BrokerSessionPayload): PendingLoginDocument;
+
+export function ensurePendingLogin(
+  config: BrokerLoginConfig,
+  options?: EnsurePendingLoginOptions,
+): Promise<PendingLoginResult>;
+
+export function loginWithBroker(
+  config: BrokerLoginConfig,
+  options?: LoginWithBrokerOptions,
+): Promise<BrokerLoginResult>;

--- a/packages/core/lib/cache.d.ts
+++ b/packages/core/lib/cache.d.ts
@@ -1,0 +1,39 @@
+export type JsonObject = Record<string, unknown>;
+
+export interface AccessToken extends JsonObject {
+  access_token: string;
+}
+
+export interface TokenDocument extends JsonObject {
+  token: AccessToken;
+  expires_at?: string | null;
+}
+
+export interface PendingLoginDocument extends JsonObject {
+  session_id: string;
+  session_secret: string;
+  login_url: string;
+  status: string;
+  created_at: string;
+  expires_at: string | null;
+  error_message: string | null;
+  poll_after_ms: number | null;
+}
+
+export interface TokenCacheConfig {
+  cacheRoot: string;
+  serverUrl: string;
+}
+
+export function serverHash(serverUrl: string): string;
+export function tokenCachePath(cacheRoot: string, serverUrl: string): string;
+export function pendingCachePath(cacheRoot: string, serverUrl: string): string;
+export function ensurePrivateDir(dirPath: string): void;
+export function readJson<T extends object = JsonObject>(filePath: string): T | null;
+export function writePrivateJson(filePath: string, payload: unknown): void;
+export function removeFile(filePath: string): void;
+export function removeTokenCache(config: TokenCacheConfig): void;
+export function parseIsoDate(value: unknown): Date | null;
+export function tokenIsUsable(cacheDocument: unknown, minTtlSeconds?: number): cacheDocument is TokenDocument;
+export function readPendingLogin(filePath: string): PendingLoginDocument | null;
+export function pendingIsExpired(pending: Pick<PendingLoginDocument, "expires_at"> | null | undefined): boolean;

--- a/packages/core/lib/config.d.ts
+++ b/packages/core/lib/config.d.ts
@@ -1,0 +1,23 @@
+export interface ResolveServerUrlOptions {
+  serverUrl?: string;
+  baseUrl?: string;
+  channel?: string;
+  defaultChannel?: string;
+}
+
+export interface ResolveAuthBaseUrlOptions {
+  authBaseUrl?: string;
+  baseUrl?: string;
+  serverUrl?: string;
+}
+
+export interface ResolveBrokerBaseUrlOptions {
+  brokerBaseUrl?: string;
+  baseUrl?: string;
+}
+
+export function expandHomePath(value: string): string;
+export function normalizeBaseUrl(baseUrl: string): string;
+export function resolveServerUrl(options?: ResolveServerUrlOptions): string;
+export function resolveAuthBaseUrl(options?: ResolveAuthBaseUrlOptions): string;
+export function resolveBrokerBaseUrl(options?: ResolveBrokerBaseUrlOptions): string;

--- a/packages/core/lib/constants.d.ts
+++ b/packages/core/lib/constants.d.ts
@@ -1,0 +1,11 @@
+export const DEFAULT_BASE_URL: "https://seleven-mcp-sg.airudder.com";
+export const DEFAULT_CHANNEL: "openagent_oauth";
+export const DEFAULT_SCOPE: "openid email profile";
+export const DEFAULT_CLIENT_NAME: "calle Login";
+export const DEFAULT_TIMEOUT_SECONDS: 15;
+export const DEFAULT_MIN_TTL_SECONDS: 300;
+export const DEFAULT_MCP_CLIENT_NAME: "calle";
+export const DEFAULT_MCP_CLIENT_VERSION: "unknown";
+export const MCP_PROTOCOL_VERSION: "2025-11-25";
+export const SESSION_SECRET_HEADER: "X-OpenAgent-Session-Secret";
+export const INTEGRATION_HEADER: "X-Call-E-Integration";

--- a/packages/core/lib/http.d.ts
+++ b/packages/core/lib/http.d.ts
@@ -1,0 +1,27 @@
+import type { JsonObject } from "./cache.js";
+
+export interface HttpStatusErrorOptions {
+  statusCode?: number | null;
+  responseText?: string;
+  headers?: Record<string, string>;
+}
+
+export interface RequestJsonOptions {
+  headers?: HeadersInit;
+  json?: unknown;
+  timeoutSeconds?: number;
+  fetchImpl?: typeof globalThis.fetch;
+}
+
+export class HttpStatusError extends Error {
+  constructor(message: string, options?: HttpStatusErrorOptions);
+  statusCode: number | null;
+  responseText: string;
+  headers: Record<string, string>;
+}
+
+export function requestJson<T extends object = JsonObject>(
+  method: string,
+  url: string,
+  options?: RequestJsonOptions,
+): Promise<T>;

--- a/packages/core/lib/index.d.ts
+++ b/packages/core/lib/index.d.ts
@@ -1,0 +1,6 @@
+export * from "./broker-client.js";
+export * from "./cache.js";
+export * from "./config.js";
+export * from "./constants.js";
+export * from "./http.js";
+export * from "./mcp-client.js";

--- a/packages/core/lib/mcp-client.d.ts
+++ b/packages/core/lib/mcp-client.d.ts
@@ -1,0 +1,61 @@
+import type { JsonObject, TokenDocument } from "./cache.js";
+
+export interface McpClientConfig {
+  cacheRoot: string;
+  serverUrl: string;
+  timeoutSeconds: number;
+  minTtlSeconds?: number;
+  integrationHeader?: string;
+  mcpClientName?: string;
+  mcpClientVersion?: string;
+  cliVersion?: string;
+}
+
+export interface McpHttpErrorOptions {
+  statusCode?: number | null;
+  responseText?: string;
+  payload?: unknown;
+  headers?: Record<string, string>;
+  code?: string;
+}
+
+export interface McpToolDefinition extends JsonObject {
+  name: string;
+  description?: string;
+  inputSchema?: JsonObject;
+}
+
+export interface McpToolList extends JsonObject {
+  tools?: McpToolDefinition[];
+}
+
+export interface McpRequestOptions {
+  config: McpClientConfig;
+  fetchImpl?: typeof globalThis.fetch;
+}
+
+export interface CallMcpToolOptions extends McpRequestOptions {
+  toolName: string;
+  toolArguments?: JsonObject;
+  requestMeta?: JsonObject | null;
+}
+
+export class AuthRequiredError extends Error {
+  constructor(message?: string);
+}
+
+export class McpHttpError extends Error {
+  constructor(message: string, options?: McpHttpErrorOptions);
+  statusCode: number | null;
+  responseText: string;
+  payload: unknown;
+  headers: Record<string, string>;
+  code: string;
+}
+
+export function isUnauthorizedMcpError(error: unknown): error is McpHttpError;
+export function currentTokenDocument(config: McpClientConfig): TokenDocument | null;
+export function listMcpTools(options: McpRequestOptions): Promise<McpToolList>;
+export function callMcpTool<TResult extends object = JsonObject>(
+  options: CallMcpToolOptions,
+): Promise<TResult>;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.2",
   "description": "Shared CALL-E runtime helpers for brokered auth, local token cache, and MCP HTTP calls.",
   "type": "module",
+  "types": "./lib/index.d.ts",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -41,7 +42,8 @@
   },
   "scripts": {
     "test": "node --test ./test/*.test.js",
-    "check": "node ../../scripts/check-runtime-syntax.mjs lib/broker-client.js lib/cache.js lib/config.js lib/constants.js lib/http.js lib/index.js lib/mcp-client.js",
+    "check": "node ../../scripts/check-runtime-syntax.mjs lib/broker-client.js lib/cache.js lib/config.js lib/constants.js lib/http.js lib/index.js lib/mcp-client.js && pnpm run check:types",
+    "check:types": "tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck test/types.ts",
     "pack:dry-run": "npm pack --dry-run"
   }
 }

--- a/packages/core/test/types.ts
+++ b/packages/core/test/types.ts
@@ -1,0 +1,65 @@
+import {
+  currentTokenDocument,
+  loginWithBroker,
+  tokenIsUsable,
+  type BrokerLoginConfig,
+} from "@call-e/core";
+import { ensurePendingLogin } from "@call-e/core/broker-client";
+import { readJson } from "@call-e/core/cache";
+import { resolveServerUrl } from "@call-e/core/config";
+import { DEFAULT_CHANNEL } from "@call-e/core/constants";
+import { requestJson } from "@call-e/core/http";
+import { callMcpTool, listMcpTools } from "@call-e/core/mcp-client";
+
+const config: BrokerLoginConfig = {
+  brokerBaseUrl: "https://example.test",
+  serverUrl: resolveServerUrl({
+    baseUrl: "https://example.test",
+    channel: DEFAULT_CHANNEL,
+  }),
+  authBaseUrl: "https://example.test",
+  channel: DEFAULT_CHANNEL,
+  scope: "openid email profile",
+  clientName: "calle Login",
+  cacheRoot: "/tmp/calle-core-types",
+  timeoutSeconds: 15,
+  minTtlSeconds: 300,
+  pollTimeoutSeconds: 300,
+};
+
+interface PlanCallResult {
+  plan_id: string;
+  ready_to_run: boolean;
+  confirm_token: string | null;
+}
+
+async function consumePublicTypes() {
+  const cached = readJson("/tmp/token.json");
+  if (tokenIsUsable(cached, config.minTtlSeconds)) {
+    cached.token.access_token.toUpperCase();
+  }
+
+  const pending = await ensurePendingLogin(config);
+  pending.pending.login_url.toUpperCase();
+
+  const login = await loginWithBroker(config, { noBrowserOpen: true });
+  login.tokenDocument.token.access_token.toUpperCase();
+
+  const token = currentTokenDocument(config);
+  token?.token.access_token.toUpperCase();
+
+  const tools = await listMcpTools({ config });
+  tools.tools?.map((tool) => tool.name);
+
+  const result = await callMcpTool<PlanCallResult>({
+    config,
+    toolName: "plan_call",
+    toolArguments: { goal: "Confirm the appointment" },
+  });
+  result.plan_id.toUpperCase();
+
+  const status = await requestJson<{ ok: boolean }>("GET", "https://example.test/status");
+  status.ok.valueOf();
+}
+
+void consumePublicTypes;


### PR DESCRIPTION
## Summary

- publish TypeScript declarations for the @call-e/core root export and every public subpath
- document authentication preflight, broker session timing, and the outbound call safety contract
- add a strict TypeScript consumer check and a patch changeset

## Runtime impact

No runtime JavaScript logic changes. Existing CLI, broker login, token cache, and MCP request behavior remain unchanged.

## Validation

- pnpm check
- pnpm test
- npm_config_cache=/tmp/calle-core-npm-cache pnpm --filter @call-e/core pack:dry-run

Closes #60
Closes #61
Closes #62
Closes #63
Closes #64