### PR TITLE
fix(deps): enforce a seven-day pnpm release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,5 +2,3 @@ packages:
   - packages/*
 
 minimumReleaseAge: 10080
-blockExoticSubdeps: true
-trustPolicy: no-downgrade

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
 packages:
   - packages/*
+
+minimumReleaseAge: 10080
+blockExoticSubdeps: true
+trustPolicy: no-downgrade


### PR DESCRIPTION
## Summary

- Adds `minimumReleaseAge: 10080` to `pnpm-workspace.yaml`, requiring newly published package versions to be at least seven days old before pnpm will install them
- Hardens dependency resolution for this repository's own development and release installs; downstream consumers of published `@call-e/*` packages control their own package-manager policy independently

## Vulnerability

| Field | Value |
|-------|-------|
| **ID** | package_managers.pnpm.pnpm-missing-minimum-release-age.pnpm-minimum-release-age |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `package_managers.pnpm.pnpm-missing-minimum-release-age.pnpm-minimum-release-age` |
| **File** | `pnpm-workspace.yaml:1` |
| **Assessment** | Defensive hardening |

**Description**: Without a minimum release age, a newly published (potentially malicious) package version could be installed immediately. Setting `minimumReleaseAge: 10080` (7 days in minutes) adds a time-based buffer. Supported since pnpm v10.16.0.

## Changes

- `pnpm-workspace.yaml` — adds `minimumReleaseAge: 10080`

## Behavior Preservation

Only affects which package versions pnpm will resolve during install. Valid, established package versions (older than seven days) are unaffected.

Supersedes #77 (closed to correct branch name).