### PR TITLE
fix(core): bound the MCP request timeout before arming setTimeout

### DIFF
--- a/.changeset/bound-mcp-request-timeout.md
+++ b/.changeset/bound-mcp-request-timeout.md
@@ -1,0 +1,10 @@
+---
+"@call-e/core": patch
+---
+
+Bound the MCP request timeout on both ends before arming setTimeout. A `callMcpTool`
+`timeoutSeconds` override or a `config.timeoutSeconds` above 2147483 seconds used to reach
+`setTimeout` unchanged, where Node collapses any delay past 2147483647ms to 1ms and aborts
+the request almost immediately. Oversized values are now capped at that ceiling. Non-finite
+or non-positive values fall back to the session timeout. This matches the cap the CLI
+already applies to `--timeout-seconds`.

--- a/.changeset/bound-mcp-request-timeout.md
+++ b/.changeset/bound-mcp-request-timeout.md
@@ -2,9 +2,13 @@
 "@call-e/core": patch
 ---
 
-Bound the MCP request timeout on both ends before arming setTimeout. A `callMcpTool`
-`timeoutSeconds` override or a `config.timeoutSeconds` above 2147483 seconds used to reach
-`setTimeout` unchanged, where Node collapses any delay past 2147483647ms to 1ms and aborts
-the request almost immediately. Oversized values are now capped at that ceiling. Non-finite
-or non-positive values fall back to the session timeout. This matches the cap the CLI
-already applies to `--timeout-seconds`.
+Validate the MCP request timeout before arming setTimeout and fall back to a safe value
+rather than capping. A `callMcpTool` `timeoutSeconds` override or a `config.timeoutSeconds`
+reaches Node's timer, where any delay past 2147483647ms (~24.8 days) collapses to 1ms and
+aborts the request almost immediately. The seconds value is now required to be finite,
+positive and no greater than 2147483 (the largest whole-second delay the timer keeps intact).
+An out-of-range or non-finite session value falls back to the 15s default; an out-of-range or
+non-finite per-call override falls back to the already computed session timeout. Capping an
+oversized value at the ceiling was worse than the abort it replaced: it turned a malformed
+value into a ~24.8-day timeout that held the request, socket and caller resources open instead
+of failing. This matches the validation the CLI already applies to `--timeout-seconds`.

--- a/packages/core/lib/mcp-client.js
+++ b/packages/core/lib/mcp-client.js
@@ -2,9 +2,27 @@ import { readJson, tokenCachePath, tokenIsUsable } from "./cache.js";
 import {
   DEFAULT_MCP_CLIENT_NAME,
   DEFAULT_MCP_CLIENT_VERSION,
+  DEFAULT_TIMEOUT_SECONDS,
   INTEGRATION_HEADER,
   MCP_PROTOCOL_VERSION,
 } from "./constants.js";
+
+// setTimeout collapses any delay above 2_147_483_647ms (~24.8 days) to 1ms, so a very
+// large timeout fires the abort almost at once and cancels the request the caller meant
+// to keep waiting on. The CLI already caps --timeout-seconds at this ceiling (see
+// packages/cli/lib/config.js), but the public callMcpTool timeoutSeconds override and a
+// caller-built config.timeoutSeconds reach the timer arithmetic below without that bound,
+// so clamp it here rather than trusting the value.
+const MIN_TIMEOUT_MS = 1000;
+const MAX_TIMEOUT_MS = 2_147_483_647;
+
+function boundedTimeoutMs(seconds, fallbackMs) {
+  const requestedMs = Math.ceil(Number(seconds) * 1000);
+  if (!Number.isFinite(requestedMs) || requestedMs <= 0) {
+    return fallbackMs;
+  }
+  return Math.min(Math.max(requestedMs, MIN_TIMEOUT_MS), MAX_TIMEOUT_MS);
+}
 
 export class AuthRequiredError extends Error {
   constructor(message = "A usable CALL-E auth token is required.") {
@@ -142,7 +160,7 @@ function accessTokenFromCache(config) {
 async function openMcpSession({ config, fetchImpl }) {
   requireFetch(fetchImpl);
   const accessToken = accessTokenFromCache(config);
-  const timeoutMs = Math.max(Math.ceil(Number(config.timeoutSeconds || 15) * 1000), 1000);
+  const timeoutMs = boundedTimeoutMs(config.timeoutSeconds, DEFAULT_TIMEOUT_SECONDS * 1000);
   const commonHeaders = {
     Accept: "application/json, text/event-stream",
     "Content-Type": "application/json",
@@ -213,7 +231,7 @@ export async function callMcpTool({
   }
   const toolCallTimeoutMs = timeoutSeconds === null
     ? timeoutMs
-    : Math.max(Math.ceil(Number(timeoutSeconds) * 1000), 1000);
+    : boundedTimeoutMs(timeoutSeconds, timeoutMs);
   const response = await requestJsonRpc(fetchImpl, config.serverUrl, {
     headers: rpcHeaders,
     payload: buildJsonRpcPayload({

--- a/packages/core/lib/mcp-client.js
+++ b/packages/core/lib/mcp-client.js
@@ -9,19 +9,23 @@ import {
 
 // setTimeout collapses any delay above 2_147_483_647ms (~24.8 days) to 1ms, so a very
 // large timeout fires the abort almost at once and cancels the request the caller meant
-// to keep waiting on. The CLI already caps --timeout-seconds at this ceiling (see
-// packages/cli/lib/config.js), but the public callMcpTool timeoutSeconds override and a
-// caller-built config.timeoutSeconds reach the timer arithmetic below without that bound,
-// so clamp it here rather than trusting the value.
+// to keep waiting on. Capping an oversized value at that ceiling instead would be worse:
+// it turns a malformed or attacker-influenced timeout into a ~24.8-day one that holds the
+// request, socket, AbortController and caller resources open rather than failing. The CLI
+// validates --timeout-seconds against this ceiling (see packages/cli/lib/config.js), but
+// the public callMcpTool timeoutSeconds override and a caller-built config.timeoutSeconds
+// reach the timer arithmetic below without it, so validate the seconds here and fall back
+// to a safe timeout rather than trusting or capping the value.
 const MIN_TIMEOUT_MS = 1000;
-const MAX_TIMEOUT_MS = 2_147_483_647;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+const MAX_TIMER_SECONDS = Math.floor(MAX_TIMER_DELAY_MS / 1000);
 
 function boundedTimeoutMs(seconds, fallbackMs) {
-  const requestedMs = Math.ceil(Number(seconds) * 1000);
-  if (!Number.isFinite(requestedMs) || requestedMs <= 0) {
+  const parsed = Number(seconds);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > MAX_TIMER_SECONDS) {
     return fallbackMs;
   }
-  return Math.min(Math.max(requestedMs, MIN_TIMEOUT_MS), MAX_TIMEOUT_MS);
+  return Math.max(Math.ceil(parsed * 1000), MIN_TIMEOUT_MS);
 }
 
 export class AuthRequiredError extends Error {

--- a/packages/core/test/core.test.js
+++ b/packages/core/test/core.test.js
@@ -488,3 +488,105 @@ test("MCP client reports request timeouts", async () => {
     },
   );
 });
+
+// The delay handed to setTimeout is decided just before each request is sent, so a stub
+// that records delays.at(-1) per method reads the exact timer armed for that request.
+async function withTimeoutDelayCapture(delays, run) {
+  const realSetTimeout = globalThis.setTimeout;
+  globalThis.setTimeout = (handler, delay, ...rest) => {
+    delays.push(delay);
+    return realSetTimeout(handler, delay, ...rest);
+  };
+  try {
+    await run();
+  } finally {
+    globalThis.setTimeout = realSetTimeout;
+  }
+}
+
+function recordingMcpFetch(delays, seen) {
+  return async (_url, init) => {
+    const payload = JSON.parse(init.body);
+    seen[payload.method] = delays.at(-1);
+    if (payload.method === "initialize") {
+      return jsonResponse({ result: {} }, { headers: { "mcp-session-id": "mcp-session-timeout" } });
+    }
+    if (payload.method === "notifications/initialized") {
+      return jsonResponse({});
+    }
+    if (payload.method === "tools/list") {
+      return jsonResponse({ result: { tools: [] } });
+    }
+    if (payload.method === "tools/call") {
+      return jsonResponse({ result: { content: [{ type: "text", text: "ok" }] } });
+    }
+    throw new Error(`Unexpected MCP method ${payload.method}`);
+  };
+}
+// APPEND-TIMEOUT-TESTS-HERE
+
+test("MCP client clamps an oversized tool-call timeout so the request is not aborted immediately", async () => {
+  const config = mcpConfig(makeTempRoot("calle-core-timeout-cap"));
+  const delays = [];
+  const seen = {};
+  await withTimeoutDelayCapture(delays, () =>
+    callMcpTool({
+      config,
+      toolName: "plan_call",
+      toolArguments: { goal: "Confirm the appointment" },
+      timeoutSeconds: 5_000_000,
+      fetchImpl: recordingMcpFetch(delays, seen),
+    }),
+  );
+  // 5_000_000s is 5e9ms, past the 2_147_483_647ms setTimeout ceiling. Unclamped it would
+  // collapse to a 1ms abort; clamped it stays at the ceiling.
+  assert.equal(seen["tools/call"], 2_147_483_647);
+});
+
+test("MCP client falls back to the session timeout when a tool-call override is unusable", async () => {
+  const config = { ...mcpConfig(makeTempRoot("calle-core-timeout-nan")), timeoutSeconds: 20 };
+  const delays = [];
+  const seen = {};
+  await withTimeoutDelayCapture(delays, () =>
+    callMcpTool({
+      config,
+      toolName: "plan_call",
+      toolArguments: { goal: "Confirm the appointment" },
+      timeoutSeconds: Number.NaN,
+      fetchImpl: recordingMcpFetch(delays, seen),
+    }),
+  );
+  // A non-finite override used to reach setTimeout as NaN, which fires at 1ms. It now
+  // falls back to the 20s session timeout the handshake computed.
+  assert.equal(seen["tools/call"], 20_000);
+});
+// APPEND-TIMEOUT-TESTS-2
+
+test("MCP client clamps an oversized session timeout from config", async () => {
+  const config = { ...mcpConfig(makeTempRoot("calle-core-session-cap")), timeoutSeconds: 5_000_000 };
+  const delays = [];
+  const seen = {};
+  await withTimeoutDelayCapture(delays, () =>
+    listMcpTools({ config, fetchImpl: recordingMcpFetch(delays, seen) }),
+  );
+  // openMcpSession derives the shared session timeout, so the handshake and the list call
+  // both stay at the ceiling instead of collapsing to a 1ms abort.
+  assert.equal(seen["initialize"], 2_147_483_647);
+  assert.equal(seen["tools/list"], 2_147_483_647);
+});
+
+test("MCP client keeps an in-range tool-call timeout unchanged", async () => {
+  const config = mcpConfig(makeTempRoot("calle-core-timeout-ok"));
+  const delays = [];
+  const seen = {};
+  await withTimeoutDelayCapture(delays, () =>
+    callMcpTool({
+      config,
+      toolName: "plan_call",
+      toolArguments: { goal: "Confirm the appointment" },
+      timeoutSeconds: 150,
+      fetchImpl: recordingMcpFetch(delays, seen),
+    }),
+  );
+  assert.equal(seen["tools/call"], 150_000);
+});

--- a/packages/core/test/core.test.js
+++ b/packages/core/test/core.test.js
@@ -523,10 +523,14 @@ function recordingMcpFetch(delays, seen) {
     throw new Error(`Unexpected MCP method ${payload.method}`);
   };
 }
-// APPEND-TIMEOUT-TESTS-HERE
+// Node's setTimeout collapses any delay above 2_147_483_647ms (~24.8 days) to 1ms, so the
+// core validates the requested seconds against this ceiling and falls back to a safe timeout
+// rather than arming the timer with a disabled or immediate-abort value. MAX_TIMER_SECONDS
+// is the largest whole-second override the timer keeps intact, matching mcp-client.js.
+const MAX_TIMER_SECONDS = Math.floor(2_147_483_647 / 1000);
 
-test("MCP client clamps an oversized tool-call timeout so the request is not aborted immediately", async () => {
-  const config = mcpConfig(makeTempRoot("calle-core-timeout-cap"));
+async function toolCallDelay(overrideSeconds, sessionTimeoutSeconds, rootName) {
+  const config = { ...mcpConfig(makeTempRoot(rootName)), timeoutSeconds: sessionTimeoutSeconds };
   const delays = [];
   const seen = {};
   await withTimeoutDelayCapture(delays, () =>
@@ -534,59 +538,72 @@ test("MCP client clamps an oversized tool-call timeout so the request is not abo
       config,
       toolName: "plan_call",
       toolArguments: { goal: "Confirm the appointment" },
-      timeoutSeconds: 5_000_000,
+      timeoutSeconds: overrideSeconds,
       fetchImpl: recordingMcpFetch(delays, seen),
     }),
   );
-  // 5_000_000s is 5e9ms, past the 2_147_483_647ms setTimeout ceiling. Unclamped it would
-  // collapse to a 1ms abort; clamped it stays at the ceiling.
-  assert.equal(seen["tools/call"], 2_147_483_647);
-});
+  return seen["tools/call"];
+}
 
-test("MCP client falls back to the session timeout when a tool-call override is unusable", async () => {
-  const config = { ...mcpConfig(makeTempRoot("calle-core-timeout-nan")), timeoutSeconds: 20 };
-  const delays = [];
-  const seen = {};
-  await withTimeoutDelayCapture(delays, () =>
-    callMcpTool({
-      config,
-      toolName: "plan_call",
-      toolArguments: { goal: "Confirm the appointment" },
-      timeoutSeconds: Number.NaN,
-      fetchImpl: recordingMcpFetch(delays, seen),
-    }),
-  );
-  // A non-finite override used to reach setTimeout as NaN, which fires at 1ms. It now
-  // falls back to the 20s session timeout the handshake computed.
-  assert.equal(seen["tools/call"], 20_000);
-});
-// APPEND-TIMEOUT-TESTS-2
-
-test("MCP client clamps an oversized session timeout from config", async () => {
-  const config = { ...mcpConfig(makeTempRoot("calle-core-session-cap")), timeoutSeconds: 5_000_000 };
+async function sessionDelays(sessionTimeoutSeconds, rootName) {
+  const config = { ...mcpConfig(makeTempRoot(rootName)), timeoutSeconds: sessionTimeoutSeconds };
   const delays = [];
   const seen = {};
   await withTimeoutDelayCapture(delays, () =>
     listMcpTools({ config, fetchImpl: recordingMcpFetch(delays, seen) }),
   );
-  // openMcpSession derives the shared session timeout, so the handshake and the list call
-  // both stay at the ceiling instead of collapsing to a 1ms abort.
-  assert.equal(seen["initialize"], 2_147_483_647);
-  assert.equal(seen["tools/list"], 2_147_483_647);
+  return seen;
+}
+
+test("MCP client falls back to the session timeout for an oversized tool-call override", async () => {
+  // One second past the ceiling is invalid, not a 24.8-day timeout, so the request keeps the
+  // 20s session timeout the handshake computed.
+  assert.equal(await toolCallDelay(MAX_TIMER_SECONDS + 1, 20, "calle-core-tool-over"), 20_000);
+});
+
+test("MCP client falls back to the session timeout for a non-finite tool-call override", async () => {
+  assert.equal(await toolCallDelay(Number.POSITIVE_INFINITY, 20, "calle-core-tool-inf"), 20_000);
+});
+
+test("MCP client falls back to the session timeout for a NaN tool-call override", async () => {
+  assert.equal(await toolCallDelay(Number.NaN, 20, "calle-core-tool-nan"), 20_000);
+});
+
+test("MCP client falls back to the session timeout for a negative tool-call override", async () => {
+  assert.equal(await toolCallDelay(-30, 20, "calle-core-tool-neg"), 20_000);
+});
+
+test("MCP client accepts a tool-call override at the timer ceiling", async () => {
+  // The boundary value is the largest delay setTimeout keeps intact, so it passes through.
+  assert.equal(await toolCallDelay(MAX_TIMER_SECONDS, 20, "calle-core-tool-max"), MAX_TIMER_SECONDS * 1000);
 });
 
 test("MCP client keeps an in-range tool-call timeout unchanged", async () => {
-  const config = mcpConfig(makeTempRoot("calle-core-timeout-ok"));
-  const delays = [];
-  const seen = {};
-  await withTimeoutDelayCapture(delays, () =>
-    callMcpTool({
-      config,
-      toolName: "plan_call",
-      toolArguments: { goal: "Confirm the appointment" },
-      timeoutSeconds: 150,
-      fetchImpl: recordingMcpFetch(delays, seen),
-    }),
-  );
-  assert.equal(seen["tools/call"], 150_000);
+  assert.equal(await toolCallDelay(150, 15, "calle-core-tool-ok"), 150_000);
+});
+
+test("MCP client falls back to the default timeout for an oversized session timeout", async () => {
+  // openMcpSession derives the shared session timeout, so an out-of-range config value falls
+  // back to the 15s default for the handshake and the list call instead of disabling the timer.
+  const seen = await sessionDelays(MAX_TIMER_SECONDS + 1, "calle-core-session-over");
+  assert.equal(seen["initialize"], 15_000);
+  assert.equal(seen["tools/list"], 15_000);
+});
+
+test("MCP client falls back to the default timeout for a non-finite session timeout", async () => {
+  const seen = await sessionDelays(Number.POSITIVE_INFINITY, "calle-core-session-inf");
+  assert.equal(seen["initialize"], 15_000);
+  assert.equal(seen["tools/list"], 15_000);
+});
+
+test("MCP client falls back to the default timeout for a negative session timeout", async () => {
+  const seen = await sessionDelays(-5, "calle-core-session-neg");
+  assert.equal(seen["initialize"], 15_000);
+  assert.equal(seen["tools/list"], 15_000);
+});
+
+test("MCP client accepts a session timeout at the timer ceiling", async () => {
+  const seen = await sessionDelays(MAX_TIMER_SECONDS, "calle-core-session-max");
+  assert.equal(seen["initialize"], MAX_TIMER_SECONDS * 1000);
+  assert.equal(seen["tools/list"], MAX_TIMER_SECONDS * 1000);
 });


### PR DESCRIPTION
## Summary

`@call-e/core` 0.3.0 gave `callMcpTool` a public `timeoutSeconds` override that the CLI passes as 150 for `plan_call`. That value, together with a `config.timeoutSeconds` built by any direct `@call-e/core` consumer, reaches the timer arithmetic in `mcp-client.js` without an upper bound:

```js
Math.max(Math.ceil(Number(timeoutSeconds) * 1000), 1000)
```

`setTimeout` collapses any delay above 2147483647ms (about 24.8 days) to 1ms, so a `timeoutSeconds` above 2147483 aborts the request almost immediately instead of waiting. A non-finite or non-positive value has the same effect, because `Math.max(NaN, 1000)` stays `NaN` and `setTimeout` treats that as 1ms.

This is the immediate-abort failure PR #73 fixed for `--timeout-seconds` at the flag boundary. The CLI validator caps that flag at `MAX_TIMER_SECONDS` and rejects non-finite durations, but the core transport does its own arithmetic, so the new public override and a caller-built config skip that guard.

## Fix

One helper in `packages/core/lib/mcp-client.js` validates the requested seconds before arming either timer:

- The value must be finite, positive and no greater than `MAX_TIMER_SECONDS` (2147483, the largest whole-second delay `setTimeout` keeps intact). An oversized, non-finite or non-positive value is treated as invalid.
- An invalid `config.timeoutSeconds` falls back to the 15s default. An invalid per-call `timeoutSeconds` override falls back to the session timeout the handshake already computed.
- In-range values are unchanged and the existing lower clamp of 1000ms is kept.

Capping an oversized value at the ceiling, which the first version of this fix did, traded the immediate abort for a worse failure: a malformed or attacker-influenced value became a roughly 24.8-day timeout that held the request, socket, AbortController and caller resources open instead of failing. Falling back fails safely.

`openMcpSession` and `callMcpTool` both call the helper, so `config.timeoutSeconds` and the per-call override are validated the same way. No public surface changes: `timeoutSeconds` is still an optional number and the helper is not exported.

## Tests

`packages/core/test/core.test.js` reads the delay handed to `setTimeout` for each request and covers both timer sites:

- an out-of-range per-call override (`MAX_TIMER_SECONDS + 1`), a non-finite one (`Infinity`, `NaN`) and a negative one all fall back to the session timeout
- the same out-of-range, non-finite and negative `config.timeoutSeconds` values fall back to the 15s default for the handshake and the list call
- a per-call override and a session value at `MAX_TIMER_SECONDS` are both accepted unchanged (the boundary)
- an in-range 150s override is passed through unchanged

The two oversized cases fail without the change, since they previously asserted the cap. Reverting only `mcp-client.js` while keeping the tests:

```text
not ok 13 - MCP client falls back to the session timeout for an oversized tool-call override
not ok 19 - MCP client falls back to the default timeout for an oversized session timeout
# tests 30  # pass 28  # fail 2
```

The non-finite and negative cases already fell back under the first version, so they pass either way. The behavior change is that an oversized value now falls back too. Every case has explicit coverage on both the session and per-call paths.

## Verification

From the repository root on Node 22.22.2 with pnpm 10.18.3.

```text
pnpm test           exit 0   core 30/30, cli 58 (57 pass, 1 skip) + 15/15
pnpm check          exit 0   tsc --noEmit clean, syntax check clean
pnpm pack:dry-run   exit 0
```

The single skip is the pre-existing Windows-only case. No CALL-E account or live call is involved; every case drives an injected `fetchImpl`.

## AI assistance

AI (Claude, Anthropic) was used in developing this change. The design, review and verification were done by the author. Verified locally before submitting: `pnpm test`, `pnpm check` and `pnpm pack:dry-run` all pass on Node 22.22.2 with pnpm 10.18.3.
