### PR TITLE
test(cli): skip recovery mode assertion on Windows

### DIFF
--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -1764,10 +1764,11 @@ test("call recover reuses the original confirmation after a run_call timeout", a
   assert.equal(firstPayload.call_started, "unknown");
   assert.equal(firstPayload.retry_safe, false);
   assert.doesNotMatch(firstResult.stdout, /plan-secret|confirm-secret/);
-  assert.equal(
-    fs.statSync(callRecoveryCachePath(cacheRoot, serverUrl, firstPayload.recovery_id)).mode & 0o777,
-    0o600
-  );
+  const recoveryPath = callRecoveryCachePath(cacheRoot, serverUrl, firstPayload.recovery_id);
+  assert.equal(fs.existsSync(recoveryPath), true);
+  if (process.platform !== "win32") {
+    assert.equal(fs.statSync(recoveryPath).mode & 0o777, 0o600);
+  }
 
   const recoveredResult = await run(
     [


### PR DESCRIPTION
## Summary

- keep verifying that the recovery cache file is created on every platform
- only assert the POSIX `0600` mode where permission bits are meaningful

## Why

Windows reports `fs.statSync(...).mode & 0o777` as `0o666` even when the file is created with mode `0o600`, because Node.js does not implement POSIX file permission semantics on Windows. The unconditional mode assertion therefore made the CLI unit suite fail on native Windows despite the recovery file being written correctly.

## Impact

The recovery behavior is unchanged. The test remains strict on POSIX systems and now validates file existence without relying on unsupported permission semantics on Windows.

## Validation

- all repository JavaScript tests: 144 passed
- CLI unit tests: 58 passed
- CLI end-to-end tests: 15 passed
- branch name, package version, install reference, runtime syntax, TypeScript, and plugin/skill metadata checks passed
- `git diff --check` passed
- `pnpm pack:dry-run` was not run because this Windows environment does not provide `npm`; the change is test-only and does not affect packaged output

## Release decision

No release needed. This changes only a CLI test, so no package behavior or published output changes and no changeset is required.
