### PR TITLE
chore: standardize community issue triage

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -1,0 +1,87 @@
+name: Bug report
+description: Report reproducible unexpected behavior in a CALL-E integration
+type: Bug
+labels:
+  - status:needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. Do not include API keys, OAuth tokens,
+        confirmation tokens, full phone numbers, personal data, or sensitive
+        call transcripts.
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      options:
+        - Core package or SDK
+        - CLI
+        - Claude, Codex, Cursor, or another plugin
+        - MCP or Developer API
+        - Calling, routing, speech, billing, or backend runtime
+        - Documentation or examples
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Include package, CLI, plugin, SDK, or API contract versions.
+      placeholder: "@call-e/core 0.x.x, calle-ai 0.x.x, CLI 0.x.x"
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, runtime, integration path, destination region, and locale where relevant.
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed behavior
+      description: What happened? Include redacted error text and safe diagnostic IDs.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened according to the product or developer contract?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: Provide the smallest reproducible steps or code sample with secrets removed.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: call_safety
+    attributes:
+      label: Could this cause an unintended, duplicate, or delayed real phone call?
+      options:
+        - "No"
+        - "Possibly"
+        - "Yes"
+        - "Not applicable"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acknowledgement
+    attributes:
+      label: Sensitive-data acknowledgement
+      options:
+        - label: I removed credentials, tokens, full phone numbers, personal data, and sensitive transcripts.
+          required: true

--- a/.github/ISSUE_TEMPLATE/02-feature.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature.yml
@@ -1,0 +1,58 @@
+name: Feature request
+description: Propose a new integration capability or product outcome
+type: Feature
+labels:
+  - status:needs-triage
+body:
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      options:
+        - Core package or SDK
+        - CLI
+        - Claude, Codex, Cursor, or another plugin
+        - MCP or Developer API
+        - Calling, routing, speech, billing, or backend runtime
+        - Documentation or examples
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: Describe the user problem before describing the implementation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: What should users be able to do when this is complete?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Current alternatives or workarounds
+    validations:
+      required: false
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation proposal
+      description: Explain how the capability can be tested end to end.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: testing
+    attributes:
+      label: Community validation
+      options:
+        - label: I can help validate this capability when it reaches a testable state.
+          required: false

--- a/.github/ISSUE_TEMPLATE/03-docs.yml
+++ b/.github/ISSUE_TEMPLATE/03-docs.yml
@@ -1,0 +1,37 @@
+name: Documentation improvement
+description: Report missing, unclear, or inaccurate documentation
+type: Task
+labels:
+  - status:needs-triage
+  - area:docs
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Documentation location
+      description: Link to the README section, guide, example, API reference, or file.
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is missing, unclear, or inaccurate?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed improvement
+      description: Explain the result the documentation should provide.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Integration context
+      description: Describe what you were trying to build or operate.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Usage, account, credits, or routing question
+    url: https://discord.gg/6AbXUzUV8w
+    about: Ask general usage and account-specific questions in the CALL-E Discord community.
+
+  - name: Security vulnerability
+    url: https://github.com/CALLE-AI/call-e-integrations/security/policy
+    about: Do not disclose security vulnerabilities or sensitive data in a public issue.

--- a/docs/community/issue-triage.md
+++ b/docs/community/issue-triage.md
@@ -1,0 +1,126 @@
+# Community issue triage
+
+This policy keeps CALL-E Integrations issues actionable, safe, and useful for
+maintainers and community contributors. Issue types identify the kind of work;
+labels identify the affected area, priority, workflow status, and whether
+community participation is appropriate.
+
+## Issue types
+
+Use the existing organization issue types. Do not duplicate them with labels.
+
+| Type | Use when |
+| --- | --- |
+| `Bug` | Existing or promised behavior is broken, a public contract is violated, or runtime behavior creates an unexpected result or safety risk. |
+| `Feature` | A user requests a capability or product outcome that does not exist yet. |
+| `Task` | The work is documentation, testing, refactoring, release, maintenance, or another concrete engineering task. |
+
+Account, billing, credit, routing-availability, and general usage questions are
+support requests rather than engineering work. Answer or redirect those through
+the configured support channel. If a support thread reveals a reproducible
+defect, track the defect in a separate `Bug` issue and link both issues.
+
+## Area labels
+
+Use one primary area in most cases and no more than two when the issue genuinely
+spans separate owners.
+
+| Label | Scope |
+| --- | --- |
+| `area:core` | Core package, shared authentication, tokens, and call-tool integration logic. |
+| `area:cli` | CALL-E CLI installation, authentication, and command behavior. |
+| `area:plugins` | Claude, Codex, Cursor, OpenClaw, and other agent integrations. |
+| `area:docs` | README files, guides, examples, API or MCP documentation, and developer guidance. |
+| `area:platform` | Deployed API, telephony routing, speech, billing, and backend runtime behavior. |
+
+## Priority labels
+
+Priority expresses impact and urgency, not implementation effort.
+
+| Label | Meaning |
+| --- | --- |
+| `priority:p1` | Critical safety or production impact requiring immediate maintainer attention, including possible delayed, duplicate, or unintended calls. |
+| `priority:p2` | Blocks meaningful usage or violates a public product or developer contract. |
+| `priority:p3` | Planned improvement, feature request, or non-blocking documentation work. |
+
+## Status labels
+
+Every open actionable issue must have exactly one status. Closed issues must not
+retain a status label.
+
+| Label | Meaning |
+| --- | --- |
+| `status:needs-triage` | New issue awaiting maintainer classification. |
+| `status:needs-info` | Waiting for specific reproducible details or environment information from the reporter. |
+| `status:needs-investigation` | Accepted report requiring maintainer investigation. |
+| `status:blocked` | Accepted work blocked by product, operations, a provider, or an upstream dependency. |
+| `status:ready-for-work` | Scope and acceptance criteria are clear and implementation can start. |
+| `status:needs-validation` | A fix or capability is available and awaiting real-world validation. |
+
+The normal flow is:
+
+```text
+needs-triage
+  -> needs-info
+  -> needs-investigation
+  -> blocked or ready-for-work
+  -> needs-validation
+  -> closed
+```
+
+Move directly between states when the evidence supports it. Do not use status
+labels to promise delivery dates.
+
+## Community labels
+
+Community labels signal genuine readiness for external contributions.
+
+| Label | Use when |
+| --- | --- |
+| `help wanted` | The solution direction and acceptance criteria are clear, and maintainers explicitly welcome an external implementation. |
+| `good first issue` | The scope is small, the edit location and validation steps are explicit, and the work requires no internal permissions or operational access. |
+
+Do not use `good first issue` as a promotional label. Apply it only after a
+maintainer has made the issue independently executable by a newcomer.
+
+## Closing reasons
+
+- Use `Completed` when the requested outcome is implemented or otherwise
+  satisfied.
+- Use `Not planned` when maintainers deliberately decline or cannot pursue the
+  work, and explain the decision respectfully.
+- Use `Duplicate` when another issue owns the same actionable scope, and link
+  the canonical issue.
+- Do not close an issue only because it has been inactive for a long time.
+- Remove every `status:*` label when closing an issue.
+
+Do not use `invalid`, `wontfix`, or `duplicate` labels as substitutes for the
+GitHub closing reason.
+
+## Titles and triage comments
+
+Write titles as concise outcomes or problems. Do not repeat issue types with
+prefixes such as `Bug:`, `Feature:`, or `[Bug]`. Avoid rewriting a reporter's
+title unless it is misleading or the issue scope has changed.
+
+Read the complete description and discussion before triaging. A maintainer
+triage comment should state the decision, type, area, priority, status, and a
+concrete next step without promising an unconfirmed delivery date. Ask for
+specific missing evidence rather than using a generic response. Avoid adding
+comments solely for historical metadata backfills.
+
+When one thread mixes support, a feature request, and a reproducible defect,
+keep the original purpose intact, split each actionable scope into its own
+issue, and link the issues in both directions.
+
+## Security and privacy
+
+Never post API keys, OAuth tokens, confirmation tokens, full phone numbers,
+personal data, sensitive call transcripts, or private internal logs in a public
+issue. Redact reproduction steps and include only diagnostic identifiers that
+are safe to disclose. Report security vulnerabilities through the repository's
+security policy rather than a public issue.
+
+For calling incidents, explicitly record whether an unintended, duplicate, or
+delayed real call is possible. Treat that uncertainty as a safety concern until
+maintainers confirm the run is terminal and cannot dispatch later.


### PR DESCRIPTION
## Summary

- add Bug, Feature, and Documentation Issue Forms with default organization Issue Types
- route account, credits, routing, and security questions to the appropriate channels
- document the Type, Area, Priority, Status, closing-reason, community-label, and safety workflow

## Why

The repository now uses an orthogonal issue taxonomy for historical and ongoing
triage. These files make that workflow durable for future community reports and
collect the information needed to investigate calling and integration problems
without requesting sensitive data.

## Impact

Contributors receive structured forms and maintainers receive consistent initial
Type and Status metadata. This does not change package behavior or published
artifacts.

## Validation

- parsed all Issue Form YAML and checked required fields, unique IDs, option types, and chooser configuration
- confirmed referenced labels and organization Issue Types exist in the live repository
- checked the forms against GitHub's current Issue Forms syntax
- `pnpm check`
- `git diff --check`

## Release

No release needed. No package or published integration behavior changes, so no
changeset is included.
