### PR TITLE
docs(cli): add Windows child-process guidance

### DIFF
--- a/.changeset/calm-windows-processes.md
+++ b/.changeset/calm-windows-processes.md
@@ -1,0 +1,5 @@
+---
+---
+
+No release: document shell-free Windows child-process guidance for Node
+integrations.

--- a/docs/install/cli.md
+++ b/docs/install/cli.md
@@ -69,3 +69,6 @@ error output includes the corresponding `help_command` to run.
 See [packages/cli/README.md](../../packages/cli/README.md) for package usage
 details, and [packages/cli/docs/cli-reference.md](../../packages/cli/docs/cli-reference.md)
 for the canonical command and option reference.
+
+When embedding the CLI in a Node application on Windows, follow the
+[shell-free child-process guidance](./troubleshooting.md#run-call-e-from-node-on-windows).

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -69,6 +69,102 @@ If the same URL works from the user's terminal but fails only inside the Cursor
 agent shell, the issue is the Cursor sandbox policy rather than CALL-E service
 availability.
 
+## Run CALL-E from Node on Windows
+
+### Symptoms
+
+A Node integration on Windows may abort while its host process exits with this
+libuv assertion:
+
+```text
+Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 94
+```
+
+This has been observed when the same long-running Node process starts CALL-E
+with asynchronous `spawn()` handles and also uses a synchronous child process,
+such as `execSync("npm root -g")`, to discover the CLI entry point.
+
+A separate shell-launch symptom can occur when a multiline `--goal` is sent
+through `cmd /c`: `cmd.exe` may split or reinterpret the arguments before the
+CLI receives them, sometimes surfacing as `Unknown option: --to-phone`.
+
+### Cause
+
+In the reported configuration, the assertion came from Node/libuv teardown in
+the embedding process after synchronous and asynchronous child-process paths
+were mixed. It is not evidence that the CALL-E CLI rejected the request or
+failed internally. The same assertion can have other causes, so apply this
+guidance when the host matches the child-process pattern above.
+
+The multiline failure is related but distinct: a command shell parses the
+command string before CALL-E sees it, so newlines and quoting may change the
+argument boundaries.
+
+### Fix
+
+Keep the embedded CLI launch asynchronous and shell-free from discovery through
+process exit:
+
+1. Install `@call-e/cli` as a dependency of the embedding application and
+   resolve its published JavaScript entry point during application startup.
+2. Start that entry point with the current Node executable and asynchronous
+   `spawn()`.
+3. Pass every CLI token as a separate array element, including the complete
+   multiline goal as one element.
+4. Set `shell: false` and wait for the child process to close before tearing
+   down the host.
+
+```js
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const cliEntry = require.resolve("@call-e/cli/bin/calle.js");
+
+export async function planCall({ phone, goal }) {
+  const child = spawn(
+    process.execPath,
+    [
+      cliEntry,
+      "call",
+      "plan",
+      "--to-phone",
+      phone,
+      "--goal",
+      goal,
+    ],
+    {
+      shell: false,
+      stdio: "inherit",
+      windowsHide: true,
+    },
+  );
+
+  const [exitCode] = await once(child, "close");
+  if (exitCode !== 0) {
+    throw new Error(`calle call plan exited with code ${exitCode}`);
+  }
+}
+```
+
+Do not route this integration path through `cmd /c`, a PowerShell command
+string, or a package-manager command shim. Do not run
+`execSync("npm root -g")` while the host still owns live asynchronous child
+handles. If a global CLI install is unavoidable, resolve its absolute entry
+path outside the long-running host, inject it as application configuration, and
+validate it before starting concurrent child work.
+
+### Verify
+
+First use the same launch pattern with `call plan --help`; this verifies the
+shell-free child path and normal process exit without a network request. Then
+use `calle call plan` with a multiline goal; planning does not place a call.
+Confirm that the integration no longer reports shell argument-parsing errors
+and that the child and host processes exit normally. If the assertion remains
+in an integration that does not match the pattern above, investigate that
+host's other child handles and teardown paths separately.
+
 ## `calle call plan` fails with `MCP request timed out for tools/call`
 
 ### Symptoms


### PR DESCRIPTION
## Summary

- add Windows Node integration guidance for the libuv teardown assertion associated with mixing synchronous discovery and live asynchronous child-process handles
- document multiline argument corruption when CALL-E is launched through `cmd /c`
- provide a shell-free `spawn(process.execPath, argv)` example that resolves the published CLI entry point, preserves multiline goals as one argument, and waits for process closure
- link the CLI installation guide to the Windows child-process troubleshooting section
- include a documentation-only empty changeset

## Validation

- `pnpm test`
- `pnpm check`
- `pnpm pack:dry-run`
- `git diff --check`
- shell-free `call plan --help` launch on macOS with Node 26

Closes CALLE-AI/awesome-phone-call-agents#177

Related to CALLE-AI/awesome-phone-call-agents#159
