### PR TITLE
fix(core): normalize content-only MCP tool results

### DIFF
--- a/.changeset/clear-mcp-tool-results.md
+++ b/.changeset/clear-mcp-tool-results.md
@@ -1,0 +1,8 @@
+---
+"@call-e/core": patch
+"@call-e/cli": patch
+---
+
+Normalize JSON object payloads from content-only MCP tool results into
+`structuredContent` while preserving the raw result envelope, and document the
+direct MCP and CLI output paths.

--- a/docs/mcp/openagent-oauth.md
+++ b/docs/mcp/openagent-oauth.md
@@ -106,6 +106,63 @@ plan_call -> run_call -> get_call_run
 `plan_call` prepares the call. `run_call` starts the prepared call. `get_call_run`
 reads progress and results.
 
+## Tool Result Envelope
+
+All three tools return an MCP `CallToolResult` inside the JSON-RPC
+`response.result` field. On the wire, `content` is the compatibility content
+array and `structuredContent` is the optional machine-readable JSON object:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "calle-plan_call",
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"plan_id\":\"plan_123\",\"ready_to_run\":true}"
+      }
+    ],
+    "structuredContent": {
+      "plan_id": "plan_123",
+      "ready_to_run": true,
+      "confirm_token": "<opaque confirmation token>"
+    }
+  }
+}
+```
+
+Prefer `structuredContent` whenever it is present. A text block containing
+serialized JSON is a compatibility representation, not a guaranteed
+`content[0].text` contract: MCP content can contain multiple text or non-text
+blocks, and the JSON text block is not required to be first.
+
+`@call-e/core` and the CALL-E CLI preserve the raw `CallToolResult`. If a
+content-only result has a text block that parses as a JSON object, they also
+expose that object locally as `structuredContent`. They do not parse prose,
+JSON arrays or scalars, Markdown fences, or combined fragments. Direct MCP
+clients that do not use `@call-e/core` must implement that fallback themselves
+when they need compatibility with a content-only response.
+
+The MCP wire name and JavaScript or TypeScript property are
+`structuredContent`. The official Python SDK 1.x uses the same attribute name;
+Python SDK 2.x exposes `structured_content` on Python objects while serializing
+the wire field as `structuredContent`. See the official Python SDK
+[field-name migration](https://github.com/modelcontextprotocol/python-sdk/blob/main/docs/migration.md#field-names-changed-from-camelcase-to-snake_case).
+
+After extracting the structured object, use these handoff fields:
+
+| Tool | Fields used by the next step |
+| --- | --- |
+| `plan_call` | `ready_to_run`, `plan_id`, `confirm_token`, and any `clarifying_questions` |
+| `run_call` | `run_id`, current `status`, and `next_step` when present |
+| `get_call_run` | `run_id`, `status`, `activity`, result fields, and `next_step` when present |
+
+These are workflow handoff fields, not an exhaustive output schema. Follow the
+current tool definitions returned by `tools/list` and do not infer fields that
+the server did not return. See the MCP specification for
+[structured tool results](https://modelcontextprotocol.io/specification/2025-11-25/server/tools#structured-content).
+
 ### `plan_call`
 
 Use `plan_call` first. It creates or refines a call plan and does not place a

--- a/packages/cli/docs/cli-reference.md
+++ b/packages/cli/docs/cli-reference.md
@@ -7,6 +7,44 @@ and any synchronized command guidance in the same change.
 Successful command stdout is JSON except `--help` and `-h`. Some
 top-level or local failures may print plain stderr.
 
+## JSON Result Envelopes
+
+`calle mcp call`, `calle call plan`, and `calle call status` wrap the MCP tool
+result in CLI metadata. Read the actionable object from
+`result.structuredContent`:
+
+```json
+{
+  "ok": true,
+  "server_url": "https://example.test/mcp/openagent_oauth",
+  "tool_name": "plan_call",
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"plan_id\":\"plan_123\",\"ready_to_run\":true}"
+      }
+    ],
+    "structuredContent": {
+      "plan_id": "plan_123",
+      "ready_to_run": true
+    }
+  }
+}
+```
+
+The CLI preserves the raw MCP `content` array. When the server omits
+`structuredContent` but one text block contains a JSON object, the CLI exposes
+that parsed object at `result.structuredContent` as a compatibility fallback.
+Plain text, invalid JSON, arrays, and scalar JSON remain content only.
+
+`call start`, `call run`, and `call recover` return workflow envelopes. Read
+the latest `get_call_run` object from `status_result.structuredContent`. When
+`run_result` is present, it is the initial `run_call` acknowledgement rather
+than the latest call state. See the
+[MCP tool result envelope](../../../docs/mcp/openagent-oauth.md#tool-result-envelope)
+for the direct protocol shape and SDK field-name differences.
+
 ## Finding Command Help
 
 Help is available at the root, command-group, and subcommand levels:

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -960,7 +960,9 @@ test("mcp call forwards plan_call arguments and request meta", async () => {
       return jsonRpcResponse({
         jsonrpc: "2.0",
         id: payload.id,
-        result: { structuredContent: { plan_id: "plan-1" } },
+        result: {
+          content: [{ type: "text", text: '{"plan_id":"plan-1"}' }],
+        },
       });
     }
     throw new Error(`unexpected method: ${payload.method}`);
@@ -1000,6 +1002,7 @@ test("mcp call forwards plan_call arguments and request meta", async () => {
   assert.equal(calls[0]._meta["openai/organization"], undefined);
   assert.equal(payload.ok, true);
   assert.equal(payload.tool_name, "plan_call");
+  assert.deepEqual(payload.result.structuredContent, { plan_id: "plan-1" });
 });
 
 test("mcp call gives plan_call an extended default timeout and honors an explicit override", async () => {
@@ -1328,21 +1331,32 @@ test("call start plans and runs without printing confirmation data", async () =>
         return jsonRpcResponse({
           jsonrpc: "2.0",
           id: payload.id,
-          result: { structuredContent: { plan_id: "plan-1", confirm_token: "confirm-1" } },
+          result: {
+            content: [
+              {
+                type: "text",
+                text: '{"plan_id":"plan-1","confirm_token":"confirm-1","ready_to_run":true}',
+              },
+            ],
+          },
         });
       }
       if (payload.params.name === "run_call") {
         return jsonRpcResponse({
           jsonrpc: "2.0",
           id: payload.id,
-          result: { structuredContent: { run_id: "run-1", status: "STARTED" } },
+          result: {
+            content: [{ type: "text", text: '{"run_id":"run-1","status":"STARTED"}' }],
+          },
         });
       }
       if (payload.params.name === "get_call_run") {
         return jsonRpcResponse({
           jsonrpc: "2.0",
           id: payload.id,
-          result: { structuredContent: { run_id: "run-1", status: "IN_PROGRESS" } },
+          result: {
+            content: [{ type: "text", text: '{"run_id":"run-1","status":"IN_PROGRESS"}' }],
+          },
         });
       }
     }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -60,6 +60,19 @@ The override applies only to the tool call. MCP session initialization keeps
 using `config.timeoutSeconds`; when the override is omitted, the tool call uses
 that configured timeout too.
 
+## Tool Result Payloads
+
+`callMcpTool` returns the MCP `CallToolResult` envelope and preserves its raw
+`content`, `isError`, and metadata fields. When `structuredContent` is absent
+but a text content block contains a JSON object, the client also exposes that
+object as `structuredContent`. Non-JSON text, arrays, and scalar JSON remain
+unchanged.
+
+See the
+[MCP tool result envelope](https://github.com/CALLE-AI/call-e-integrations/blob/main/docs/mcp/openagent-oauth.md#tool-result-envelope)
+for the direct wire shape, compatibility fallback, and Python SDK field-name
+differences.
+
 ## Broker Login Lifetime
 
 Broker session timing is server-directed:

--- a/packages/core/lib/mcp-client.js
+++ b/packages/core/lib/mcp-client.js
@@ -122,6 +122,57 @@ function nonEmptyMetaObject(value) {
   return Object.keys(value).length > 0 ? value : null;
 }
 
+function objectRecord(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value;
+}
+
+function jsonObjectFromTextContent(content) {
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  for (const item of content) {
+    if (item?.type !== "text" || typeof item.text !== "string" || !item.text.trim()) {
+      continue;
+    }
+    try {
+      const parsed = objectRecord(JSON.parse(item.text));
+      if (parsed) {
+        return parsed;
+      }
+    } catch {
+      // Text content is not required to contain JSON.
+    }
+  }
+
+  return null;
+}
+
+function normalizeMcpToolResult(result) {
+  const envelope = objectRecord(result);
+  if (!envelope) {
+    return {};
+  }
+
+  if (objectRecord(envelope.structuredContent)) {
+    return envelope;
+  }
+
+  const structuredContent = objectRecord(envelope.structured_content)
+    || jsonObjectFromTextContent(envelope.content);
+  if (!structuredContent) {
+    return envelope;
+  }
+
+  return {
+    ...envelope,
+    structuredContent,
+  };
+}
+
 export function currentTokenDocument(config) {
   const cacheDocument = readJson(tokenCachePath(config.cacheRoot, config.serverUrl));
   if (!tokenIsUsable(cacheDocument, config.minTtlSeconds)) {
@@ -223,5 +274,5 @@ export async function callMcpTool({
     }),
     timeoutMs: toolCallTimeoutMs,
   });
-  return response.body?.result ?? {};
+  return normalizeMcpToolResult(response.body?.result);
 }

--- a/packages/core/test/core.test.js
+++ b/packages/core/test/core.test.js
@@ -394,6 +394,71 @@ test("MCP client calls tools through an initialized session", async () => {
   assert.deepEqual(result, { content: [{ type: "text", text: "ok" }] });
 });
 
+test("MCP client normalizes tool payloads without discarding the raw envelope", async () => {
+  const config = mcpConfig(makeTempRoot("calle-core-mcp-tool-payload"));
+  const toolResults = [
+    {
+      content: [{ type: "text", text: '{"plan_id":"plan-text","ready_to_run":true}' }],
+      isError: false,
+      _meta: { trace_id: "trace-1" },
+    },
+    {
+      content: [{ type: "text", text: '{"plan_id":"plan-text"}' }],
+      structuredContent: { plan_id: "plan-camel" },
+      structured_content: { plan_id: "plan-snake" },
+    },
+    {
+      content: [{ type: "text", text: '{"plan_id":"plan-text"}' }],
+      structured_content: { plan_id: "plan-snake" },
+    },
+    {
+      content: [
+        { type: "text", text: "not json" },
+        { type: "text", text: '["not","an","object"]' },
+        { type: "image", data: "ignored", mimeType: "image/png" },
+        { type: "text", text: '{"run_id":"run-text"}' },
+      ],
+    },
+    {
+      content: [
+        { type: "text", text: "not json" },
+        { type: "text", text: "42" },
+      ],
+    },
+  ];
+  let toolCallIndex = 0;
+  const fetchImpl = async (_url, init) => {
+    const payload = JSON.parse(init.body);
+    if (payload.method === "initialize") {
+      return jsonResponse({ result: {} }, { headers: { "mcp-session-id": "mcp-session-payload" } });
+    }
+    if (payload.method === "notifications/initialized") {
+      return jsonResponse({});
+    }
+    if (payload.method === "tools/call") {
+      const result = toolResults[toolCallIndex];
+      toolCallIndex += 1;
+      return jsonResponse({ result });
+    }
+    throw new Error(`Unexpected MCP method ${payload.method}`);
+  };
+
+  const results = [];
+  for (let index = 0; index < toolResults.length; index += 1) {
+    results.push(await callMcpTool({ config, toolName: "plan_call", fetchImpl }));
+  }
+
+  assert.deepEqual(results[0].structuredContent, { plan_id: "plan-text", ready_to_run: true });
+  assert.deepEqual(results[0].content, toolResults[0].content);
+  assert.equal(results[0].isError, false);
+  assert.deepEqual(results[0]._meta, { trace_id: "trace-1" });
+  assert.deepEqual(results[1].structuredContent, { plan_id: "plan-camel" });
+  assert.deepEqual(results[2].structuredContent, { plan_id: "plan-snake" });
+  assert.deepEqual(results[2].structured_content, { plan_id: "plan-snake" });
+  assert.deepEqual(results[3].structuredContent, { run_id: "run-text" });
+  assert.deepEqual(results[4], toolResults[4]);
+});
+
 test("MCP client forwards request meta on tool calls", async () => {
   const config = mcpConfig(makeTempRoot("calle-core-mcp-call-meta"));
   const fetchImpl = async (_url, init) => {


### PR DESCRIPTION
## Summary

- preserve the raw MCP tool-result envelope while exposing an existing `structuredContent` or `structured_content` object through the canonical `structuredContent` field
- parse a JSON object from a text content block when a content-only result omits structured content
- leave prose, invalid JSON, arrays, scalar JSON, Markdown fences, and combined fragments unchanged
- apply the normalized result to direct MCP calls and the `plan_call` / `run_call` / `get_call_run` CLI workflow
- document the raw MCP envelope, SDK field names, workflow handoff fields, and stable CLI result paths

## Testing

- `pnpm test`
- `pnpm check`
- `pnpm pack:dry-run`
- `git diff --check`

## Release

Adds patch changesets for `@call-e/core` and `@call-e/cli`.

Relates to CALLE-AI/awesome-phone-call-agents#158
