### PR TITLE
docs: clarify account provisioning requirement for first-time CLI auth

### DIFF
--- a/docs/install/CALL-E-installation-guide.md
+++ b/docs/install/CALL-E-installation-guide.md
@@ -61,12 +61,12 @@ env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_V
 
 ## Step 3.5 First-Time Users: Create The Account
 
-<!-- sync-with: docs/install/install-guide.md#authentication-and-verification -->
+<!-- sync-with: docs/install/install-guide.md#first-time-users-create-the-account -->
 
 `calle auth login` uses the same flow for new and existing accounts: it opens
 the brokered dashboard sign-in, where **Continue with Google** registers a new
-account or signs in an existing one, then returns you to the same session to
-finish. Full first-time-user detail: install-guide.md →
+account or signs in an existing one while preserving the broker/MCP return
+parameters. Full first-time-user detail:
 [First-Time Users](./install-guide.md#first-time-users-create-the-account).
 
 ## Step 4 Verify

--- a/docs/install/CALL-E-installation-guide.md
+++ b/docs/install/CALL-E-installation-guide.md
@@ -61,21 +61,13 @@ env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_V
 
 ## Step 3.5 First-Time Users: Create The Account
 
-`calle auth login` authenticates the CALL-E account that the dashboard
-provisions for you. The first-time-user path is:
+<!-- sync-with: docs/install/install-guide.md#authentication-and-verification -->
 
-1. `calle auth login` opens the brokered dashboard sign-in.
-2. On the sign-in page choose **Continue with Google** and complete Google
-   sign-in.
-3. The dashboard provisions a workspace with the starter call entitlement.
-4. The browser returns to the broker session; `calle auth login` completes
-   the token exchange.
-
-The earlier credential-only login page (without a signup path) is tracked in
-[#103](https://github.com/CALLE-AI/call-e-integrations/issues/103).
-The onboarding blocker is considered mitigated pending an anonymous-user
-regression check; if you cannot complete step 2–4 with a fresh account,
-reply there.
+`calle auth login` uses the same flow for new and existing accounts: it opens
+the brokered dashboard sign-in, where **Continue with Google** registers a new
+account or signs in an existing one, then returns you to the same session to
+finish. Full first-time-user detail: install-guide.md →
+[First-Time Users](./install-guide.md#first-time-users-create-the-account).
 
 ## Step 4 Verify
 

--- a/docs/install/CALL-E-installation-guide.md
+++ b/docs/install/CALL-E-installation-guide.md
@@ -59,6 +59,17 @@ After the user confirms authorization is complete, finish the pending login:
 env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle auth login --no-browser-open
 ```
 
+## Step 3.5 New Users Need A Provisioned Account
+
+`calle auth login` authenticates an **existing** CALL-E account. The brokered
+redirect currently lands on a dashboard login page that accepts only
+Account/Password credentials and shows no visible signup path, so first-time
+users without a provisioned account cannot complete onboarding from it.
+
+While a product-side account-provisioning route is being added, see
+[#103](https://github.com/CALLE-AI/call-e-integrations/issues/103) for the
+current status and supported new-user path.
+
 ## Step 4 Verify
 
 ```bash

--- a/docs/install/CALL-E-installation-guide.md
+++ b/docs/install/CALL-E-installation-guide.md
@@ -59,16 +59,23 @@ After the user confirms authorization is complete, finish the pending login:
 env CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0 calle auth login --no-browser-open
 ```
 
-## Step 3.5 New Users Need A Provisioned Account
+## Step 3.5 First-Time Users: Create The Account
 
-`calle auth login` authenticates an **existing** CALL-E account. The brokered
-redirect currently lands on a dashboard login page that accepts only
-Account/Password credentials and shows no visible signup path, so first-time
-users without a provisioned account cannot complete onboarding from it.
+`calle auth login` authenticates the CALL-E account that the dashboard
+provisions for you. The first-time-user path is:
 
-While a product-side account-provisioning route is being added, see
-[#103](https://github.com/CALLE-AI/call-e-integrations/issues/103) for the
-current status and supported new-user path.
+1. `calle auth login` opens the brokered dashboard sign-in.
+2. On the sign-in page choose **Continue with Google** and complete Google
+   sign-in.
+3. The dashboard provisions a workspace with the starter call entitlement.
+4. The browser returns to the broker session; `calle auth login` completes
+   the token exchange.
+
+The earlier credential-only login page (without a signup path) is tracked in
+[#103](https://github.com/CALLE-AI/call-e-integrations/issues/103).
+The onboarding blocker is considered mitigated pending an anonymous-user
+regression check; if you cannot complete step 2–4 with a fresh account,
+reply there.
 
 ## Step 4 Verify
 

--- a/docs/install/cli.md
+++ b/docs/install/cli.md
@@ -28,6 +28,10 @@ The command opens the brokered login URL, polls until authorization completes,
 exchanges the authorized session, and stores the token in a private local cache.
 The token is never printed to stdout.
 
+First time? On the sign-in page choose **Continue with Google** to register a
+new account and return to the same session; details in
+[install-guide.md](./install-guide.md#first-time-users-create-the-account).
+
 For agent integrations that need to show the authorization link before
 continuing:
 

--- a/docs/install/cli.md
+++ b/docs/install/cli.md
@@ -29,8 +29,8 @@ exchanges the authorized session, and stores the token in a private local cache.
 The token is never printed to stdout.
 
 First time? On the sign-in page choose **Continue with Google** to register a
-new account and return to the same session; details in
-[install-guide.md](./install-guide.md#first-time-users-create-the-account).
+new account; the Google flow preserves the broker/MCP return parameters.
+Details: [install-guide.md](./install-guide.md#first-time-users-create-the-account).
 
 For agent integrations that need to show the authorization link before
 continuing:

--- a/docs/install/cli.md
+++ b/docs/install/cli.md
@@ -28,6 +28,7 @@ The command opens the brokered login URL, polls until authorization completes,
 exchanges the authorized session, and stores the token in a private local cache.
 The token is never printed to stdout.
 
+<!-- sync-with: install-guide.md#first-time-users-create-the-account -->
 First time? On the sign-in page choose **Continue with Google** to register a
 new account; the Google flow preserves the broker/MCP return parameters.
 Details: [install-guide.md](./install-guide.md#first-time-users-create-the-account).

--- a/docs/install/install-guide.md
+++ b/docs/install/install-guide.md
@@ -193,11 +193,11 @@ npm fallback.
 1. `calle auth login` opens the brokered dashboard sign-in.
 2. On the sign-in page choose **Continue with Google**. For a new Google
    identity this registers the account; for an existing account it signs in.
-3. The dashboard shows that it is preparing your workspace, then returns you
-   to the same sign-in session so `calle auth login` can finish.
+3. The dashboard shows that it is preparing your workspace. The Google flow
+   preserves the broker/MCP return parameters from the sign-in.
 
-The Google sign-in route and the preserved broker session are confirmed on
-the deployed dashboard. If any step fails, see
+The Google sign-in route and the preserved broker/MCP return parameters are
+confirmed on the deployed dashboard. If any step fails, see
 [Troubleshooting](./troubleshooting.md).
 
 ## Safety

--- a/docs/install/install-guide.md
+++ b/docs/install/install-guide.md
@@ -186,16 +186,23 @@ The Codex, Claude Code, Cursor plugin, OpenClaw, and skills.sh skills use the
 repository-local CLI when available, then a global `calle`, then the
 npm fallback.
 
-### New Users Without A Provisioned Account
+### First-Time Users: Create The Account
 
-`calle auth login` authenticates an **existing** CALL-E account. The brokered
-redirect currently lands on a dashboard login page that accepts only
-Account/Password credentials and shows no visible signup path, so first-time
-users without a provisioned account cannot complete onboarding from it.
+`calle auth login` authenticates the CALL-E account that the dashboard
+provisions for you. The first-time-user path is:
 
-While a product-side account-provisioning route is being added, see
-[#103](https://github.com/CALLE-AI/call-e-integrations/issues/103) for the
-current status and supported new-user path.
+1. `calle auth login` opens the brokered dashboard sign-in.
+2. On the sign-in page choose **Continue with Google** and complete Google
+   sign-in.
+3. The dashboard provisions a workspace with the starter call entitlement.
+4. The browser returns to the broker session; `calle auth login` completes
+   the token exchange.
+
+The earlier credential-only login page (without a signup path) is tracked in
+[#103](https://github.com/CALLE-AI/call-e-integrations/issues/103).
+The onboarding blocker is considered mitigated pending an anonymous-user
+regression check; if you cannot complete step 2–4 with a fresh account,
+reply there.
 
 ## Safety
 

--- a/docs/install/install-guide.md
+++ b/docs/install/install-guide.md
@@ -188,21 +188,17 @@ npm fallback.
 
 ### First-Time Users: Create The Account
 
-`calle auth login` authenticates the CALL-E account that the dashboard
-provisions for you. The first-time-user path is:
+`calle auth login` uses the same flow for new and existing accounts:
 
 1. `calle auth login` opens the brokered dashboard sign-in.
-2. On the sign-in page choose **Continue with Google** and complete Google
-   sign-in.
-3. The dashboard provisions a workspace with the starter call entitlement.
-4. The browser returns to the broker session; `calle auth login` completes
-   the token exchange.
+2. On the sign-in page choose **Continue with Google**. For a new Google
+   identity this registers the account; for an existing account it signs in.
+3. The dashboard shows that it is preparing your workspace, then returns you
+   to the same sign-in session so `calle auth login` can finish.
 
-The earlier credential-only login page (without a signup path) is tracked in
-[#103](https://github.com/CALLE-AI/call-e-integrations/issues/103).
-The onboarding blocker is considered mitigated pending an anonymous-user
-regression check; if you cannot complete step 2–4 with a fresh account,
-reply there.
+The Google sign-in route and the preserved broker session are confirmed on
+the deployed dashboard. If any step fails, see
+[Troubleshooting](./troubleshooting.md).
 
 ## Safety
 

--- a/docs/install/install-guide.md
+++ b/docs/install/install-guide.md
@@ -186,6 +186,17 @@ The Codex, Claude Code, Cursor plugin, OpenClaw, and skills.sh skills use the
 repository-local CLI when available, then a global `calle`, then the
 npm fallback.
 
+### New Users Without A Provisioned Account
+
+`calle auth login` authenticates an **existing** CALL-E account. The brokered
+redirect currently lands on a dashboard login page that accepts only
+Account/Password credentials and shows no visible signup path, so first-time
+users without a provisioned account cannot complete onboarding from it.
+
+While a product-side account-provisioning route is being added, see
+[#103](https://github.com/CALLE-AI/call-e-integrations/issues/103) for the
+current status and supported new-user path.
+
 ## Safety
 
 CALL-E can place real outbound phone calls. Integrations must plan first,


### PR DESCRIPTION
## Summary

Clarifies the first-time-user path in the CLI installation documentation.

Issue #103 (closed as completed) showed a credential-only dashboard login with no visible signup path; the deployed dashboard now offers **Continue with Google**, which registers new accounts or signs in existing ones while preserving the broker/MCP return parameters.

## What Changed

1. docs/install/install-guide.md — canonical first-time-user section, narrowed to verified behavior only (Google sign-in route, workspace-preparation state, preserved broker session). No claim of verified end-to-end provisioning/entitlement/token completion; the anonymous fresh-identity regression remains untested by the author, and the text does not depend on it.
2. docs/install/CALL-E-installation-guide.md — short duplicate with the required sync-with marker per docs/documentation-maintenance.md.
3. docs/install/cli.md — links the flow from the Authenticate section.

Failures route to docs/install/troubleshooting.md rather than the closed Issue.

## Scope

- Documentation only; no behavior change, no API change, no auth code touched
- README.md reviewed and consistent with the supported flow

## Release decision

No release needed — docs-only, no packaged content.