### PR TITLE
docs: fix README API key placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ pip install calle-ai
 **Set your API key:**
 
 ```bash
-export CALLE_API_KEY="calle_live_key"
+export CALLE_API_KEY="iams_live_example"
 ```
 
 Get your API key from the [CALL-E dashboard](https://dashboard.heycall-e.com/account/api-keys).
@@ -258,7 +258,7 @@ The CALL-E Developer API provides direct HTTP access for any trusted backend, wo
 **Set credentials:**
 
 ```bash
-export CALLE_API_KEY="calle_live_key"
+export CALLE_API_KEY="iams_live_example"
 export CALLE_BASE_URL="https://api.heycall-e.com"
 ```
 


### PR DESCRIPTION
Both README credential examples now use `iams_live_example`, matching the Developer Docs authentication guide. Checked the related docs, packages, skills, and examples; no `calle_live` placeholders remain.

Closes #107.

Validation:

- Executed the README shell exports, TypeScript and Python SDK examples (both SDKs at 0.7.0), and curl examples against a local HTTP receiver. All six requests carried the expected Bearer value; methods, paths, and request bodies matched. TypeScript strict type checking passed.
- Executed the README result-reading curl command against the live API: the literal placeholder returned 401; a real test key and an existing test Call ID returned 200. No phone calls were created.
- `pnpm test`, `pnpm check`, `pnpm pack:dry-run`, and `git diff --check` passed.
- The additional `pnpm check:examples` run failed in the unchanged Python MCP OAuth example: `OAuthClientProvider` rejects `timeout`. Reproduced on clean main (`e497e1a`) with `uv run --isolated pytest -q test_e2e.py::test_oauth_client_completes_auth_and_mcp_calls`. Its `mcp>=1.27.0` dependency resolved to 2.1.1.

Release decision: **No release needed**. Only the root README changes; no affected package, changeset, version bump, or release command.
