### PR TITLE
fix(examples): migrate Python OAuth client to MCP v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,13 @@ jobs:
       - name: Run checks
         run: pnpm check
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          python-version: "3.12"
+
+      - name: Test Python OAuth example
+        run: uv run --isolated --project examples/mcp-oauth-client/python pytest examples/mcp-oauth-client/python
+
       - name: Validate package contents
         run: pnpm pack:dry-run

--- a/examples/mcp-oauth-client/README.md
+++ b/examples/mcp-oauth-client/README.md
@@ -64,6 +64,8 @@ pnpm test:e2e
 
 ## Python
 
+The Python example uses MCP Python SDK 2.x and `httpx2`.
+
 ```bash
 cd examples/mcp-oauth-client/python
 uv sync

--- a/examples/mcp-oauth-client/python/client.py
+++ b/examples/mcp-oauth-client/python/client.py
@@ -199,7 +199,7 @@ async def run_client() -> None:
     )
 
     async with httpx2.AsyncClient(
-        auth=oauth, timeout=30.0, event_hooks={"response": [capture_session_id]}
+        auth=oauth, timeout=30.0, follow_redirects=True, event_hooks={"response": [capture_session_id]}
     ) as http_client:
         async with streamable_http_client(config["server_url"], http_client=http_client) as (read, write):
             async with ClientSession(read, write) as session:

--- a/examples/mcp-oauth-client/python/client.py
+++ b/examples/mcp-oauth-client/python/client.py
@@ -8,9 +8,9 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
-import httpx
+import httpx2
 from mcp import ClientSession
-from mcp.client.auth import OAuthClientProvider, TokenStorage
+from mcp.client.auth import AuthorizationCodeResult, OAuthClientProvider, TokenStorage
 from mcp.client.streamable_http import streamable_http_client
 from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
 
@@ -101,8 +101,8 @@ def read_config() -> dict[str, Any]:
     }
 
 
-async def complete_authorization_automatically(authorization_url: str) -> tuple[str, str | None]:
-    async with httpx.AsyncClient(follow_redirects=False, timeout=10.0) as client:
+async def complete_authorization_automatically(authorization_url: str) -> AuthorizationCodeResult:
+    async with httpx2.AsyncClient(follow_redirects=False, timeout=10.0) as client:
         response = await client.get(authorization_url)
     location = response.headers.get("location")
     if not location:
@@ -113,10 +113,10 @@ async def complete_authorization_automatically(authorization_url: str) -> tuple[
     state = params.get("state", [None])[0]
     if not code:
         raise RuntimeError("Auto authorization redirect did not include a code")
-    return code, state
+    return AuthorizationCodeResult(code=code, state=state, iss=params.get("iss", [None])[0])
 
 
-async def wait_for_local_callback(redirect_uri: str, authorization_url: str) -> tuple[str, str | None]:
+async def wait_for_local_callback(redirect_uri: str, authorization_url: str) -> AuthorizationCodeResult:
     parsed_redirect = urlparse(redirect_uri)
     if parsed_redirect.hostname not in {"127.0.0.1", "localhost"}:
         raise RuntimeError("Only localhost redirect URIs can be handled by this example")
@@ -137,6 +137,7 @@ async def wait_for_local_callback(redirect_uri: str, authorization_url: str) -> 
             params = parse_qs(parsed.query)
             result["code"] = params.get("code", [None])[0]
             result["state"] = params.get("state", [None])[0]
+            result["iss"] = params.get("iss", [None])[0]
             self.send_response(200 if result["code"] else 400)
             self.end_headers()
             self.wfile.write(b"Authorization complete. You can return to the terminal.")
@@ -158,18 +159,23 @@ async def wait_for_local_callback(redirect_uri: str, authorization_url: str) -> 
     code = result.get("code")
     if not code:
         raise RuntimeError("OAuth callback did not include a code")
-    return code, result.get("state")
+    return AuthorizationCodeResult(code=code, state=result.get("state"), iss=result.get("iss"))
 
 
 async def run_client() -> None:
     config = read_config()
     latest_authorization_url: str | None = None
+    session_id: str | None = None
+
+    async def capture_session_id(response: httpx2.Response) -> None:
+        nonlocal session_id
+        session_id = response.headers.get("mcp-session-id", session_id)
 
     async def redirect_handler(authorization_url: str) -> None:
         nonlocal latest_authorization_url
         latest_authorization_url = authorization_url
 
-    async def callback_handler() -> tuple[str, str | None]:
+    async def callback_handler() -> AuthorizationCodeResult:
         if not latest_authorization_url:
             raise RuntimeError("OAuth callback requested before authorization URL was produced")
         if config["auto_authorize"]:
@@ -190,14 +196,15 @@ async def run_client() -> None:
         storage=InMemoryTokenStorage(),
         redirect_handler=redirect_handler,
         callback_handler=callback_handler,
-        timeout=300,
     )
 
-    async with httpx.AsyncClient(auth=oauth, timeout=30.0) as http_client:
-        async with streamable_http_client(config["server_url"], http_client=http_client) as (read, write, get_session_id):
+    async with httpx2.AsyncClient(
+        auth=oauth, timeout=30.0, event_hooks={"response": [capture_session_id]}
+    ) as http_client:
+        async with streamable_http_client(config["server_url"], http_client=http_client) as (read, write):
             async with ClientSession(read, write) as session:
                 await session.initialize()
-                emit("connected", server_url=config["server_url"], session_id=get_session_id())
+                emit("connected", server_url=config["server_url"], session_id=session_id)
 
                 tools = await session.list_tools()
                 emit("tools/list", count=len(tools.tools), tools=[tool.name for tool in tools.tools])

--- a/examples/mcp-oauth-client/python/pyproject.toml
+++ b/examples/mcp-oauth-client/python/pyproject.toml
@@ -4,8 +4,8 @@ version = "0.0.0"
 description = "Minimal standard MCP OAuth client example for CALL-E."
 requires-python = ">=3.10"
 dependencies = [
-  "httpx>=0.28.1",
-  "mcp>=1.27.0",
+  "httpx2>=2.5.0,<3",
+  "mcp>=2.1.1,<3",
 ]
 
 [dependency-groups]

--- a/examples/mcp-oauth-client/python/test_e2e.py
+++ b/examples/mcp-oauth-client/python/test_e2e.py
@@ -1,10 +1,15 @@
 import json
 import os
+import queue
+import socket
 import subprocess
 import sys
 import tempfile
+import threading
 from pathlib import Path
 from urllib.request import urlopen
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -12,12 +17,14 @@ EXAMPLE = Path(__file__).resolve().parent
 FAKE_SERVER = ROOT / "shared" / "fake-mcp-broker-server.mjs"
 
 
-def start_fake_server(*, no_resources=False, unauthorized_mcp=False):
+def start_fake_server(*, no_resources=False, unauthorized_mcp=False, oauth_issuer=None):
     env = os.environ.copy()
     if no_resources:
         env["FAKE_NO_RESOURCES"] = "1"
     if unauthorized_mcp:
         env["FAKE_UNAUTHORIZED_MCP"] = "1"
+    if oauth_issuer:
+        env["FAKE_OAUTH_ISSUER"] = oauth_issuer
     process = subprocess.Popen(
         ["node", str(FAKE_SERVER)],
         stdout=subprocess.PIPE,
@@ -50,6 +57,46 @@ def run_client(env):
     )
 
 
+def run_client_with_callback(env):
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        redirect_uri = f"http://127.0.0.1:{listener.getsockname()[1]}/callback"
+    process = subprocess.Popen(
+        [sys.executable, "client.py"],
+        cwd=EXAMPLE,
+        env={**os.environ, **env, "MCP_REDIRECT_URI": redirect_uri,
+             "MCP_OAUTH_AUTO_AUTHORIZE": "0", "PYTHONUNBUFFERED": "1", "FORCE_COLOR": "0"},
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    authorization = queue.Queue()
+    lines = []
+
+    def read_authorization():
+        for line in process.stdout:
+            lines.append(line)
+            event = json.loads(line)
+            if event.get("event") == "oauth_authorization_required":
+                authorization.put(event["authorization_url"])
+                return
+        authorization.put(None)
+
+    threading.Thread(target=read_authorization, daemon=True).start()
+    try:
+        authorization_url = authorization.get(timeout=20)
+        assert authorization_url is not None, process.stderr.read()
+        with urlopen(authorization_url, timeout=5) as response:
+            assert response.status == 200
+            assert "Authorization complete" in response.read().decode()
+        stdout, stderr = process.communicate(timeout=20)
+        return subprocess.CompletedProcess(process.args, process.returncode, "".join(lines) + stdout, stderr)
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=5)
+
+
 def read_state(state_url):
     with urlopen(state_url, timeout=5) as response:
         return json.loads(response.read().decode("utf-8"))
@@ -76,6 +123,8 @@ def test_oauth_client_completes_auth_and_mcp_calls():
             }
         )
         assert result.returncode == 0, result.stderr
+        connected = next(json.loads(line) for line in result.stdout.splitlines() if '"event":"connected"' in line)
+        assert connected["session_id"] == "fake-mcp-session"
         assert '"event":"tools/list"' in result.stdout
         assert '"event":"tools/call"' in result.stdout
         assert '"event":"resources/read"' in result.stdout
@@ -135,5 +184,43 @@ def test_oauth_client_reports_repeated_401_without_leaking_tokens():
         assert result.returncode != 0
         assert "oauth_client_error" in result.stderr
         assert_no_secrets(result.stdout + result.stderr)
+        state = read_state(fake["state_url"])
+        assert len(state["oauth_registers"]) == 1
+        assert len(state["oauth_authorizes"]) >= 1
+        assert len(state["oauth_tokens"]) >= 1
+        assert not state["mcp_requests"][0]["has_bearer_token"]
+        assert any(request["has_bearer_token"] for request in state["mcp_requests"][1:])
+        assert state["tool_calls"] == []
+    finally:
+        stop_fake_server(process)
+
+
+@pytest.mark.parametrize("auto_authorize", [True, False])
+@pytest.mark.parametrize("issuer", ["valid", "mismatch"])
+def test_oauth_client_validates_callback_issuer(auto_authorize, issuer):
+    process, fake = start_fake_server(oauth_issuer=issuer)
+    try:
+        env = {
+            "MCP_SERVER_URL": fake["server_url"],
+            "MCP_REDIRECT_URI": "http://127.0.0.1:8090/callback",
+            "MCP_OAUTH_AUTO_AUTHORIZE": "1",
+        }
+        result = run_client(env) if auto_authorize else run_client_with_callback(env)
+        state = read_state(fake["state_url"])
+        assert len(state["oauth_registers"]) == 1
+        assert len(state["oauth_authorizes"]) == 1
+        assert_no_secrets(result.stdout + result.stderr)
+        if issuer == "valid":
+            assert result.returncode == 0, result.stderr
+            connected = next(json.loads(line) for line in result.stdout.splitlines() if '"event":"connected"' in line)
+            assert connected["session_id"] == "fake-mcp-session"
+            assert len(state["oauth_tokens"]) == 1
+            assert '"event":"tools/list"' in result.stdout
+            assert '"event":"resources/read"' in result.stdout
+        else:
+            assert result.returncode != 0
+            assert "oauth_client_error" in result.stderr
+            assert state["oauth_tokens"] == []
+            assert not any(request["has_bearer_token"] for request in state["mcp_requests"])
     finally:
         stop_fake_server(process)

--- a/examples/mcp-oauth-client/python/test_e2e.py
+++ b/examples/mcp-oauth-client/python/test_e2e.py
@@ -17,7 +17,7 @@ EXAMPLE = Path(__file__).resolve().parent
 FAKE_SERVER = ROOT / "shared" / "fake-mcp-broker-server.mjs"
 
 
-def start_fake_server(*, no_resources=False, unauthorized_mcp=False, oauth_issuer=None):
+def start_fake_server(*, no_resources=False, unauthorized_mcp=False, oauth_issuer=None, oauth_redirects=False):
     env = os.environ.copy()
     if no_resources:
         env["FAKE_NO_RESOURCES"] = "1"
@@ -25,6 +25,8 @@ def start_fake_server(*, no_resources=False, unauthorized_mcp=False, oauth_issue
         env["FAKE_UNAUTHORIZED_MCP"] = "1"
     if oauth_issuer:
         env["FAKE_OAUTH_ISSUER"] = oauth_issuer
+    if oauth_redirects:
+        env["FAKE_OAUTH_REDIRECTS"] = "1"
     process = subprocess.Popen(
         ["node", str(FAKE_SERVER)],
         stdout=subprocess.PIPE,
@@ -222,5 +224,32 @@ def test_oauth_client_validates_callback_issuer(auto_authorize, issuer):
             assert "oauth_client_error" in result.stderr
             assert state["oauth_tokens"] == []
             assert not any(request["has_bearer_token"] for request in state["mcp_requests"])
+    finally:
+        stop_fake_server(process)
+
+
+def test_oauth_client_follows_registration_and_token_redirects():
+    process, fake = start_fake_server(oauth_redirects=True)
+    try:
+        result = run_client({
+            "MCP_SERVER_URL": fake["server_url"],
+            "MCP_REDIRECT_URI": "http://127.0.0.1:8090/callback",
+            "MCP_OAUTH_AUTO_AUTHORIZE": "1",
+            "MCP_TOOL_NAME": "plan_call",
+            "MCP_TOOL_ARGS_JSON": '{"user_input":"Plan a short test call. Do not start it."}',
+        })
+        assert result.returncode == 0, result.stderr
+        state = read_state(fake["state_url"])
+        assert [request["path"] for request in state["oauth_redirects"]] == ["/register", "/token"]
+        assert len(state["oauth_registers"]) == len(state["oauth_tokens"]) == 1
+        assert state["oauth_registers"][0]["body_preserved"]
+        assert state["oauth_registers"][0]["redirect_uris"] == ["http://127.0.0.1:8090/callback"]
+        assert state["oauth_tokens"][0]["body_preserved"]
+        assert state["oauth_tokens"][0]["grant_type"] == "authorization_code"
+        assert state["oauth_tokens"][0]["has_code"]
+        assert state["oauth_tokens"][0]["pkce_verified"]
+        assert [call["name"] for call in state["tool_calls"]] == ["plan_call"]
+        assert '"event":"resources/read"' in result.stdout
+        assert_no_secrets(result.stdout + result.stderr)
     finally:
         stop_fake_server(process)

--- a/examples/shared/fake-mcp-broker-server.mjs
+++ b/examples/shared/fake-mcp-broker-server.mjs
@@ -75,6 +75,7 @@ function normalizeOptions(options = {}) {
     noResources: Boolean(options.noResources),
     unauthorizedMcp: Boolean(options.unauthorizedMcp),
     brokerPendingFirst: Boolean(options.brokerPendingFirst),
+    oauthIssuer: options.oauthIssuer || null,
   };
 }
 
@@ -512,6 +513,7 @@ export async function startFakeServer(options = {}) {
           grant_types_supported: ["authorization_code", "refresh_token"],
           code_challenge_methods_supported: ["S256"],
           token_endpoint_auth_methods_supported: ["none", "client_secret_post", "client_secret_basic"],
+          ...(opts.oauthIssuer ? { authorization_response_iss_parameter_supported: true } : {}),
         });
         return;
       }
@@ -546,6 +548,9 @@ export async function startFakeServer(options = {}) {
         const stateParam = requestUrl.searchParams.get("state");
         if (stateParam) {
           callbackUrl.searchParams.set("state", stateParam);
+        }
+        if (opts.oauthIssuer) {
+          callbackUrl.searchParams.set("iss", opts.oauthIssuer === "mismatch" ? `${baseUrl}/other-issuer` : baseUrl);
         }
         state.oauth_authorizes.push({
           client_id: requestUrl.searchParams.get("client_id"),
@@ -612,6 +617,7 @@ async function runCli() {
     noResources: process.env.FAKE_NO_RESOURCES === "1",
     unauthorizedMcp: process.env.FAKE_UNAUTHORIZED_MCP === "1",
     brokerPendingFirst: process.env.FAKE_BROKER_PENDING_FIRST === "1",
+    oauthIssuer: process.env.FAKE_OAUTH_ISSUER,
   });
   process.stdout.write(
     `${JSON.stringify({

--- a/examples/shared/fake-mcp-broker-server.mjs
+++ b/examples/shared/fake-mcp-broker-server.mjs
@@ -1,4 +1,5 @@
 import http from "node:http";
+import { createHash } from "node:crypto";
 import { pathToFileURL } from "node:url";
 
 const ACCESS_TOKEN = "fake-access-token";
@@ -76,6 +77,7 @@ function normalizeOptions(options = {}) {
     unauthorizedMcp: Boolean(options.unauthorizedMcp),
     brokerPendingFirst: Boolean(options.brokerPendingFirst),
     oauthIssuer: options.oauthIssuer || null,
+    oauthRedirects: Boolean(options.oauthRedirects),
   };
 }
 
@@ -83,6 +85,7 @@ export async function startFakeServer(options = {}) {
   const opts = normalizeOptions(options);
   let baseUrl = "";
   let brokerStatusCount = 0;
+  let codeChallenge = null;
   const state = {
     broker_creates: [],
     broker_status_count: 0,
@@ -90,6 +93,7 @@ export async function startFakeServer(options = {}) {
     oauth_registers: [],
     oauth_authorizes: [],
     oauth_tokens: [],
+    oauth_redirects: [],
     mcp_requests: [],
     tool_calls: [],
     get_call_run_counts: {},
@@ -99,12 +103,14 @@ export async function startFakeServer(options = {}) {
 
   function resetState() {
     brokerStatusCount = 0;
+    codeChallenge = null;
     state.broker_creates = [];
     state.broker_status_count = 0;
     state.broker_exchange_count = 0;
     state.oauth_registers = [];
     state.oauth_authorizes = [];
     state.oauth_tokens = [];
+    state.oauth_redirects = [];
     state.mcp_requests = [];
     state.tool_calls = [];
     state.get_call_run_counts = {};
@@ -504,6 +510,10 @@ export async function startFakeServer(options = {}) {
       }
 
       if (req.method === "GET" && pathname === "/.well-known/oauth-authorization-server") {
+        if (opts.oauthRedirects) {
+          jsonResponse(res, { error: "metadata unavailable" }, { status: 404 });
+          return;
+        }
         jsonResponse(res, {
           issuer: baseUrl,
           authorization_endpoint: `${baseUrl}/authorize`,
@@ -518,12 +528,26 @@ export async function startFakeServer(options = {}) {
         return;
       }
 
-      if (req.method === "POST" && pathname === "/register") {
-        const body = await readJson(req);
+      if (opts.oauthRedirects && req.method === "POST" && ["/register", "/token"].includes(pathname)) {
+        state.oauth_redirects.push({
+          path: pathname,
+          body_hash: createHash("sha256").update(await readBody(req)).digest("hex"),
+        });
+        res.writeHead(307, { location: `${baseUrl}/mcp-auth${pathname}` });
+        res.end();
+        return;
+      }
+
+      if (req.method === "POST" && (pathname === "/register" || (opts.oauthRedirects && pathname === "/mcp-auth/register"))) {
+        const raw = await readBody(req);
+        const body = raw ? JSON.parse(raw) : {};
         state.oauth_registers.push({
           redirect_uris: body.redirect_uris,
           scope: body.scope,
           client_name: body.client_name,
+          ...(opts.oauthRedirects ? {
+            body_preserved: createHash("sha256").update(raw).digest("hex") === state.oauth_redirects.find((request) => request.path === "/register")?.body_hash,
+          } : {}),
         });
         jsonResponse(
           res,
@@ -552,6 +576,7 @@ export async function startFakeServer(options = {}) {
         if (opts.oauthIssuer) {
           callbackUrl.searchParams.set("iss", opts.oauthIssuer === "mismatch" ? `${baseUrl}/other-issuer` : baseUrl);
         }
+        codeChallenge = requestUrl.searchParams.get("code_challenge");
         state.oauth_authorizes.push({
           client_id: requestUrl.searchParams.get("client_id"),
           scope: requestUrl.searchParams.get("scope"),
@@ -563,13 +588,18 @@ export async function startFakeServer(options = {}) {
         return;
       }
 
-      if (req.method === "POST" && pathname === "/token") {
-        const form = readForm(await readBody(req));
+      if (req.method === "POST" && (pathname === "/token" || (opts.oauthRedirects && pathname === "/mcp-auth/token"))) {
+        const raw = await readBody(req);
+        const form = readForm(raw);
         state.oauth_tokens.push({
           grant_type: form.grant_type,
           client_id: form.client_id || null,
           has_code: Boolean(form.code),
           has_code_verifier: Boolean(form.code_verifier),
+          ...(opts.oauthRedirects ? {
+            body_preserved: createHash("sha256").update(raw).digest("hex") === state.oauth_redirects.find((request) => request.path === "/token")?.body_hash,
+            pkce_verified: createHash("sha256").update(form.code_verifier || "").digest("base64url") === codeChallenge,
+          } : {}),
         });
         jsonResponse(res, {
           access_token: ACCESS_TOKEN,
@@ -618,6 +648,7 @@ async function runCli() {
     unauthorizedMcp: process.env.FAKE_UNAUTHORIZED_MCP === "1",
     brokerPendingFirst: process.env.FAKE_BROKER_PENDING_FIRST === "1",
     oauthIssuer: process.env.FAKE_OAUTH_ISSUER,
+    oauthRedirects: process.env.FAKE_OAUTH_REDIRECTS === "1",
   });
   process.stdout.write(
     `${JSON.stringify({


### PR DESCRIPTION
The Python OAuth example works with MCP 2.x and follows CALL-E's registration and token redirects. It uses `httpx2`, returns `AuthorizationCodeResult` with the callback issuer, and preserves the session ID in connection logs.

CI runs the Python OAuth tests. Coverage includes both authorization callback paths, issuer rejection before token exchange, repeated 401 responses, and missing discovery metadata followed by 307 redirects. The redirect test checks that POST bodies and PKCE survive both hops.

Validation:

- Ran the final example against production with browser login: registration returned 201 after a 307, token exchange returned 200 after a 307, and `plan_call` returned 200 with `is_error=false` and `ready_to_run=false`. Tool listing and resource listing/reading also succeeded. No phone call was created.
- Eight local OAuth end-to-end tests passed on Python 3.10, 3.12, and 3.14 with MCP 2.1.1. Python 3.10 also passed with the minimum declared `httpx2` version, 2.5.0.
- `pnpm run check:examples` passed all 27 tests, including the other clients that use the shared test server.
- `pnpm test`, `pnpm check`, `pnpm pack:dry-run`, and `git diff --check` passed. The package suite has one existing Windows-only test skipped on macOS.

Updated the OAuth README; checked the Python README, example indexes, MCP guide, and package/skill references for related copies.

Release decision: **No release needed**. The example and test server are outside published packages. No affected package, changeset, version bump, or release command.
